### PR TITLE
fix(dashboard): portable gateway status detection

### DIFF
--- a/SYSTEM/dashboard/server/lib/workspace.ts
+++ b/SYSTEM/dashboard/server/lib/workspace.ts
@@ -1155,13 +1155,19 @@ function readAgentInfo(id: string, agentDir: string, validationWarnings?: string
     let gatewayRunning = false
 
     if (gatewayConfig && gatewayConfig.port) {
-      try {
-        const { execSync } = require('child_process')
-        // Check if gateway port is listening
-        execSync(`lsof -ti:${gatewayConfig.port}`, { encoding: 'utf-8', stdio: 'pipe' })
-        gatewayRunning = true
-      } catch {
-        gatewayRunning = false
+      // Probe gateway port — try multiple methods for portability
+      const { execSync } = require('child_process')
+      const portChecks = [
+        `lsof -ti:${gatewayConfig.port}`,
+        `bash -c 'echo > /dev/tcp/127.0.0.1/${gatewayConfig.port}' 2>/dev/null`,
+        `curl -s -o /dev/null --connect-timeout 1 http://127.0.0.1:${gatewayConfig.port}/`,
+      ]
+      for (const cmd of portChecks) {
+        try {
+          execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 2000 })
+          gatewayRunning = true
+          break
+        } catch {}
       }
     }
 


### PR DESCRIPTION
## Summary
- Replace lsof-only port check with a fallback chain for gateway status detection
- Tries `lsof` first (macOS/Linux), then `bash /dev/tcp` (Linux without lsof), then `curl` (universal HTTP fallback)
- Each probe has a 2-second timeout to avoid blocking the dashboard

## Test plan
- [ ] Verify agent status detection works on macOS (lsof path)
- [ ] Verify fallback to `/dev/tcp` on Linux without lsof
- [ ] Verify fallback to `curl` when neither lsof nor /dev/tcp are available
- [ ] Verify status caching still works (5s TTL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)