### PR TITLE
fix: resolve schema paths reliably in both dev and prod builds

### DIFF
--- a/SYSTEM/dashboard/server/lib/paths.ts
+++ b/SYSTEM/dashboard/server/lib/paths.ts
@@ -1,0 +1,49 @@
+import path from 'path'
+import fs from 'fs'
+
+/**
+ * Resolve the repository root directory.
+ *
+ * Works in both dev (`ts-node server/...`) and prod (`node dist/server/...`)
+ * by walking up from __dirname until we find the repo marker (`.git` directory
+ * or the root `README.md` + `SYSTEM/` combo).
+ *
+ * Falls back to the legacy __dirname arithmetic so we never silently break.
+ */
+function findRepoRoot(): string {
+  // Walk up from this file's directory looking for repo markers
+  let dir = __dirname
+  const root = path.parse(dir).root
+
+  while (dir !== root) {
+    // Primary marker: .git directory at repo root
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      return dir
+    }
+    // Secondary marker: SYSTEM/schemas directory (our schema home)
+    if (
+      fs.existsSync(path.join(dir, 'SYSTEM', 'schemas')) &&
+      fs.existsSync(path.join(dir, 'AGENTS'))
+    ) {
+      return dir
+    }
+    dir = path.dirname(dir)
+  }
+
+  // Fallback: assume dev layout (server/lib -> 4 levels up)
+  // This preserves existing behaviour if markers are missing
+  console.warn('[paths] Could not locate repo root via markers — falling back to __dirname arithmetic')
+  return path.resolve(__dirname, '../../../..')
+}
+
+/** Absolute path to the repository root */
+export const REPO_ROOT = findRepoRoot()
+
+/** Absolute path to SYSTEM/schemas/ (validation schemas for workspace docs) */
+export const SCHEMAS_DIR = path.join(REPO_ROOT, 'SYSTEM', 'schemas')
+
+/** Absolute path to SYSTEM/dashboard/server/schemas/ (template schemas) */
+export const TEMPLATE_SCHEMAS_DIR = path.join(REPO_ROOT, 'SYSTEM', 'dashboard', 'server', 'schemas')
+
+/** Absolute path to TEMPLATES/ (global system templates) */
+export const TEMPLATES_DIR = path.join(REPO_ROOT, 'TEMPLATES')

--- a/SYSTEM/dashboard/server/lib/templates.ts
+++ b/SYSTEM/dashboard/server/lib/templates.ts
@@ -4,16 +4,13 @@ import Ajv from 'ajv'
 import { execSync } from 'child_process'
 import { getWorkspacePath, getAgentsDir, parseIdentity, listAgents, parseGroups, readWorkspaceFile, writeWorkspaceFile } from './workspace'
 import { listWorkflows, createWorkflow } from './workflows'
+import { TEMPLATES_DIR, TEMPLATE_SCHEMAS_DIR } from './paths'
 
 // Template storage paths (dynamic functions)
 
 // Global templates (shared across all workspaces - ClawMax system templates)
 export function getGlobalTemplatesDir(): string {
-  // Derive repo root from this file's location:
-  // this file is at SYSTEM/dashboard/server/lib/templates.ts
-  // repo root is 4 levels up
-  const repoRoot = path.resolve(__dirname, '../../../..')
-  return path.join(repoRoot, 'TEMPLATES')
+  return TEMPLATES_DIR
 }
 
 export function getGlobalAgentTemplatesDir(): string {
@@ -138,8 +135,8 @@ export type Template = AgentTemplate | OrganizationTemplate
 const ajv = new Ajv({ strict: false, validateFormats: false })
 
 // Load schemas
-const agentSchemaPath = path.join(__dirname, '..', 'schemas', 'agent-template.schema.json')
-const orgSchemaPath = path.join(__dirname, '..', 'schemas', 'organization-template.schema.json')
+const agentSchemaPath = path.join(TEMPLATE_SCHEMAS_DIR, 'agent-template.schema.json')
+const orgSchemaPath = path.join(TEMPLATE_SCHEMAS_DIR, 'organization-template.schema.json')
 
 const agentSchema = JSON.parse(fs.readFileSync(agentSchemaPath, 'utf-8'))
 const orgSchema = JSON.parse(fs.readFileSync(orgSchemaPath, 'utf-8'))

--- a/SYSTEM/dashboard/server/lib/validator.ts
+++ b/SYSTEM/dashboard/server/lib/validator.ts
@@ -1,11 +1,9 @@
 import Ajv, { ValidateFunction } from 'ajv'
 import fs from 'fs'
 import path from 'path'
+import { SCHEMAS_DIR } from './paths'
 
 const ajv = new Ajv({ allErrors: true, strict: false })
-
-// Repo root: this file is at SYSTEM/dashboard/server/lib/validator.ts
-const REPO_ROOT = path.resolve(__dirname, '../../../..')
 
 // Schema cache
 const schemas: Record<string, ValidateFunction> = {}
@@ -18,7 +16,7 @@ function loadSchema(schemaName: string): ValidateFunction {
     return schemas[schemaName]
   }
 
-  const schemaPath = path.join(REPO_ROOT, 'SYSTEM', 'schemas', `${schemaName}.schema.json`)
+  const schemaPath = path.join(SCHEMAS_DIR, `${schemaName}.schema.json`)
   try {
     const schemaContent = fs.readFileSync(schemaPath, 'utf-8')
     const schema = JSON.parse(schemaContent)


### PR DESCRIPTION
## Summary

Fixes #7 — Schema path errors in logs.

## Problem

`validator.ts` and `templates.ts` resolved schema file paths using `__dirname`-relative arithmetic (e.g. `path.resolve(__dirname, '../../../..')`) to find the repo root. This works under `ts-node` (dev) where `__dirname` is `server/lib/`, but breaks after `tsc` compilation where `__dirname` becomes `dist/server/lib/` — adding an extra directory level that shifts the resolved root to `SYSTEM/` instead of the actual repo root.

**Affected paths:**
- `validator.ts`: `REPO_ROOT` resolved to `SYSTEM/` instead of repo root → schema files not found
- `templates.ts`: `getGlobalTemplatesDir()` pointed to wrong location; template schema paths (`agent-template.schema.json`, `organization-template.schema.json`) resolved into non-existent `dist/server/schemas/`

## Fix

Introduces a shared `paths.ts` module that walks up from `__dirname` looking for reliable repo markers (`.git` directory or `SYSTEM/schemas` + `AGENTS` directories). Both `validator.ts` and `templates.ts` now import path constants from this module instead of computing them inline.

### Changes
- **New:** `server/lib/paths.ts` — exports `REPO_ROOT`, `SCHEMAS_DIR`, `TEMPLATE_SCHEMAS_DIR`, `TEMPLATES_DIR`
- **Updated:** `server/lib/validator.ts` — uses `SCHEMAS_DIR` from paths module
- **Updated:** `server/lib/templates.ts` — uses `TEMPLATES_DIR` and `TEMPLATE_SCHEMAS_DIR` from paths module

## Testing

- `tsc --noEmit` passes cleanly
- Path resolution verified for both dev (`ts-node`) and prod (`node dist/`) directory layouts