### PR TITLE
fix: resolve schema paths dynamically instead of hardcoded __dirname traversals

### DIFF
--- a/SYSTEM/dashboard/server/lib/paths.ts
+++ b/SYSTEM/dashboard/server/lib/paths.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import fs from 'fs'
+
+/**
+ * Walk up from __dirname looking for the .git directory to find repo root.
+ * Works in both dev (ts-node from server/lib/) and production (compiled to dist/server/lib/).
+ */
+export function findRepoRoot(): string {
+  let dir = __dirname
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      return dir
+    }
+    dir = path.dirname(dir)
+  }
+  throw new Error('Could not find repo root (.git directory) from ' + __dirname)
+}

--- a/SYSTEM/dashboard/server/lib/templates.ts
+++ b/SYSTEM/dashboard/server/lib/templates.ts
@@ -4,16 +4,13 @@ import Ajv from 'ajv'
 import { execSync } from 'child_process'
 import { getWorkspacePath, getAgentsDir, parseIdentity, listAgents, parseGroups, readWorkspaceFile, writeWorkspaceFile } from './workspace'
 import { listWorkflows, createWorkflow } from './workflows'
+import { findRepoRoot } from './paths'
 
 // Template storage paths (dynamic functions)
 
 // Global templates (shared across all workspaces - ClawMax system templates)
 export function getGlobalTemplatesDir(): string {
-  // Derive repo root from this file's location:
-  // this file is at SYSTEM/dashboard/server/lib/templates.ts
-  // repo root is 4 levels up
-  const repoRoot = path.resolve(__dirname, '../../../..')
-  return path.join(repoRoot, 'TEMPLATES')
+  return path.join(findRepoRoot(), 'TEMPLATES')
 }
 
 export function getGlobalAgentTemplatesDir(): string {
@@ -138,8 +135,8 @@ export type Template = AgentTemplate | OrganizationTemplate
 const ajv = new Ajv({ strict: false, validateFormats: false })
 
 // Load schemas
-const agentSchemaPath = path.join(__dirname, '..', 'schemas', 'agent-template.schema.json')
-const orgSchemaPath = path.join(__dirname, '..', 'schemas', 'organization-template.schema.json')
+const agentSchemaPath = path.join(findRepoRoot(), 'SYSTEM', 'dashboard', 'server', 'schemas', 'agent-template.schema.json')
+const orgSchemaPath = path.join(findRepoRoot(), 'SYSTEM', 'dashboard', 'server', 'schemas', 'organization-template.schema.json')
 
 const agentSchema = JSON.parse(fs.readFileSync(agentSchemaPath, 'utf-8'))
 const orgSchema = JSON.parse(fs.readFileSync(orgSchemaPath, 'utf-8'))

--- a/SYSTEM/dashboard/server/lib/validator.ts
+++ b/SYSTEM/dashboard/server/lib/validator.ts
@@ -1,11 +1,11 @@
 import Ajv, { ValidateFunction } from 'ajv'
 import fs from 'fs'
 import path from 'path'
+import { findRepoRoot } from './paths'
 
 const ajv = new Ajv({ allErrors: true, strict: false })
 
-// Repo root: this file is at SYSTEM/dashboard/server/lib/validator.ts
-const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const REPO_ROOT = findRepoRoot()
 
 // Schema cache
 const schemas: Record<string, ValidateFunction> = {}


### PR DESCRIPTION
## Summary

Fixes #7 — Schema path errors in logs.

## Problem

`validator.ts` and `templates.ts` resolved schema file paths using hardcoded `__dirname` parent traversals (e.g., `path.resolve(__dirname, '../../../..')`). This works in dev (`ts-node` where `__dirname` = `SYSTEM/dashboard/server/lib/`), but **breaks in production** when compiled to `dist/server/lib/` — the fixed number of `../` no longer reaches the repo root.

## Fix

- Created a shared `findRepoRoot()` utility in `paths.ts` that walks up from `__dirname` looking for the `.git` directory
- Replaced all hardcoded `__dirname` traversals in `validator.ts` and `templates.ts` with `findRepoRoot()`
- Schema paths now resolve correctly regardless of whether code runs from source or compiled output

## Changes

| File | Change |
|------|--------|
| `server/lib/paths.ts` | **New** — shared `findRepoRoot()` utility |
| `server/lib/validator.ts` | Use `findRepoRoot()` instead of `path.resolve(__dirname, '../../../..')` |
| `server/lib/templates.ts` | Use `findRepoRoot()` for both TEMPLATES dir and template schema paths |

## Testing

Works in both:
- **Dev:** `ts-node` (source paths)
- **Prod:** compiled to `dist/` (output paths)