### PR TITLE
feat: OpenClaw Hack Day — weave-cli skills, RAG Team template, dashboard fixes

### DIFF
--- a/SYSTEM/dashboard/client/src/App.tsx
+++ b/SYSTEM/dashboard/client/src/App.tsx
@@ -188,14 +188,24 @@ export default function App() {
     return () => clearInterval(interval)
   }, [])
 
-  // Poll for unread message counts
+  // Poll for unread message counts (scoped to current workspace channels)
   useEffect(() => {
     const checkUnread = () => {
-      fetch('/api/message-counts').then(r => r.ok ? r.json() : {}).then(d => {
+      Promise.all([
+        fetch('/api/message-counts').then(r => r.ok ? r.json() : {}),
+        fetch('/api/channels/groups').then(r => r.ok ? r.json() : { groups: [] }),
+        fetch('/api/channels/communities').then(r => r.ok ? r.json() : { communities: [] }),
+      ]).then(([d, g, c]) => {
         const counts = d.counts || {}
         const lastSeen = JSON.parse(localStorage.getItem('clawmax-last-seen-counts') || '{}')
+        // Only count channels that exist in the current workspace
+        const validKeys = new Set([
+          ...(g.groups || []).map((gr: any) => `group:${gr.name}`),
+          ...(c.communities || []).map((co: any) => `community:${co.name}`),
+        ])
         let total = 0
         for (const [key, count] of Object.entries(counts)) {
+          if (!validKeys.has(key)) continue
           const seen = lastSeen[key] || 0
           if ((count as number) > seen) total += (count as number) - seen
         }

--- a/SYSTEM/dashboard/client/src/components/AgentChatPanel.tsx
+++ b/SYSTEM/dashboard/client/src/components/AgentChatPanel.tsx
@@ -643,8 +643,10 @@ export default function AgentChatPanel({ agentId, agentName, agentStatus, onClos
                   </>
                 ) : (
                   <>
-                    <div className="text-sm whitespace-pre-wrap break-words">
-                      {msg.content || ''}
+                    <div className="text-sm prose prose-sm prose-invert max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {msg.content || ''}
+                      </ReactMarkdown>
                     </div>
                     <div className="text-xs opacity-60 mt-1">
                       {new Date(msg.timestamp).toLocaleTimeString()}

--- a/SYSTEM/dashboard/client/src/components/ApplyOrgTemplateModal.tsx
+++ b/SYSTEM/dashboard/client/src/components/ApplyOrgTemplateModal.tsx
@@ -15,7 +15,7 @@ interface OrganizationTemplate {
   version: string
   description?: string
   parameters?: TemplateParameter[]
-  agents: Array<{ id: string; name?: string; role: string; model?: string; tags?: string[] }>
+  agents: Array<{ id: string; name?: string; role: string; model?: string; tags?: string[]; skills?: string[] }>
   communities?: Array<{ name: string }>
   groups?: Array<{ name: string }>
   workflows?: Array<{ id: string; name: string }>
@@ -303,7 +303,7 @@ export default function ApplyOrgTemplateModal({ template, onClose, onSuccess }: 
               className="w-full px-4 py-3 flex items-center justify-between bg-gray-50 hover:bg-gray-100 transition-colors dark:bg-gray-800 dark:hover:bg-gray-700"
             >
               <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Agents & Models ({agentsToCreate.length} agent{agentsToCreate.length !== 1 ? 's' : ''})
+                Agents, Skills & Models ({agentsToCreate.length} agent{agentsToCreate.length !== 1 ? 's' : ''})
               </h3>
               <span className="text-gray-400 text-xs">{showModelSection ? '▼' : '▶'}</span>
             </button>
@@ -317,6 +317,7 @@ export default function ApplyOrgTemplateModal({ template, onClose, onSuccess }: 
                       <tr className="bg-gray-100 dark:bg-gray-800">
                         <th className="px-3 py-2 text-left text-gray-600 dark:text-gray-400">Agent</th>
                         <th className="px-3 py-2 text-left text-gray-600 dark:text-gray-400">Role</th>
+                        <th className="px-3 py-2 text-left text-gray-600 dark:text-gray-400">Skills</th>
                         <th className="px-3 py-2 text-left text-gray-600 dark:text-gray-400">Model</th>
                       </tr>
                     </thead>
@@ -329,6 +330,17 @@ export default function ApplyOrgTemplateModal({ template, onClose, onSuccess }: 
                           <tr key={idx} className="border-t border-gray-100 dark:border-gray-800">
                             <td className="px-3 py-2 font-mono font-medium text-sky-700 dark:text-sky-400">{newId}</td>
                             <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{agent.role}</td>
+                            <td className="px-3 py-2">
+                              {agent.skills && agent.skills.length > 0 ? (
+                                <div className="flex flex-wrap gap-1">
+                                  {agent.skills.map(s => (
+                                    <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-700">{s}</span>
+                                  ))}
+                                </div>
+                              ) : (
+                                <span className="text-gray-400">none</span>
+                              )}
+                            </td>
                             <td className="px-3 py-2">
                               <span className={isOverridden ? 'text-amber-600 dark:text-amber-400' : 'text-gray-600 dark:text-gray-400'}>
                                 {effectiveModel}

--- a/SYSTEM/dashboard/client/src/components/ChatPanel.tsx
+++ b/SYSTEM/dashboard/client/src/components/ChatPanel.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -253,7 +255,11 @@ export default function ChatPanel({ agentId, agentName, onClose }: Props) {
                     : 'bg-gray-100 text-gray-800'
                 }`}
               >
-                <p className="text-sm whitespace-pre-wrap break-words">{msg.content}</p>
+                <div className={`text-sm prose prose-sm max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${msg.role === 'user' ? 'prose-invert' : 'dark:prose-invert'}`}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {msg.content}
+                  </ReactMarkdown>
+                </div>
               </div>
             </div>
           ))}
@@ -431,7 +437,11 @@ export default function ChatPanel({ agentId, agentName, onClose }: Props) {
                         <p className="text-xs text-gray-500 mb-1">
                           {msg.timestamp ? new Date(msg.timestamp).toLocaleString() : ''}
                         </p>
-                        <p className="text-sm whitespace-pre-wrap break-words">{msg.content}</p>
+                        <div className={`text-sm prose prose-sm max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${msg.role === 'user' ? 'prose-invert' : 'dark:prose-invert'}`}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {msg.content}
+                  </ReactMarkdown>
+                </div>
                       </div>
                     </div>
                   ))

--- a/SYSTEM/dashboard/client/src/components/GroupChatPanel.tsx
+++ b/SYSTEM/dashboard/client/src/components/GroupChatPanel.tsx
@@ -726,7 +726,11 @@ export default function GroupChatPanel({ channel, onClose, mode = 'overlay', onE
                   </ReactMarkdown>
                 </div>
               ) : (
-                <p className="text-sm text-gray-800 whitespace-pre-wrap break-words dark:text-gray-200">{msg.content}</p>
+                <div className="text-sm prose prose-sm dark:prose-invert max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {msg.content}
+                  </ReactMarkdown>
+                </div>
               )}
             </div>
           ))}

--- a/SYSTEM/dashboard/client/src/components/skills/SkillCard.tsx
+++ b/SYSTEM/dashboard/client/src/components/skills/SkillCard.tsx
@@ -36,6 +36,15 @@ export function SkillCard({ skill, assigned, onToggle, compact = false, usageCou
             {skill.description}
           </p>
 
+          {/* Tags */}
+          {skill.tags && skill.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {skill.tags.map(tag => (
+                <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-sky-50 dark:bg-sky-900/30 text-sky-600 dark:text-sky-400 border border-sky-200 dark:border-sky-700">{tag}</span>
+              ))}
+            </div>
+          )}
+
           {/* Usage information */}
           {usageCount !== undefined && usageCount > 0 && (
             <p className="text-xs text-gray-500 mt-1">
@@ -106,7 +115,9 @@ export function SkillCard({ skill, assigned, onToggle, compact = false, usageCou
                       {option.kind === 'brew' && `brew install ${option.formula}`}
                       {option.kind === 'apt' && `apt install ${option.package}`}
                       {option.kind === 'npm' && `npm install -g ${option.package}`}
-                      {option.kind === 'go' && `go install ${option.module}`}
+                      {option.kind === 'go' && `go install ${option.module || option.package}`}
+                      {option.kind === 'uv' && `uv tool install ${option.package}`}
+                      {!['brew', 'apt', 'npm', 'go', 'uv'].includes(option.kind) && option.label}
                     </div>
                   ))}
                 </div>

--- a/SYSTEM/dashboard/client/src/pages/Agents.tsx
+++ b/SYSTEM/dashboard/client/src/pages/Agents.tsx
@@ -158,10 +158,11 @@ export default function Agents({ onNavigateToDoc, onNavigateToGroup, onNavigateT
     fetch(url)
       .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() })
       .then(d => {
+        const normalized = (d.agents || []).map((a: any) => ({ ...a, tags: a.tags || [] }))
         if (resetPagination) {
-          setAgents(d.agents || [])
+          setAgents(normalized)
         } else {
-          setAgents(prev => [...prev, ...(d.agents || [])])
+          setAgents(prev => [...prev, ...normalized])
         }
         setHasMore(d.hasMore || false)
         setNextCursor(d.nextCursor || null)
@@ -730,9 +731,10 @@ export default function Agents({ onNavigateToDoc, onNavigateToGroup, onNavigateT
     const primaryTags = new Set<string>() // Tags that are first for at least one agent
 
     agents.forEach(a => {
-      a.tags.forEach(t => tags.add(t))
-      if (a.tags.length > 0) {
-        primaryTags.add(a.tags[0]) // First tag is primary
+      const agentTags = a.tags || []
+      agentTags.forEach(t => tags.add(t))
+      if (agentTags.length > 0) {
+        primaryTags.add(agentTags[0]) // First tag is primary
       }
     })
 
@@ -1189,10 +1191,25 @@ export default function Agents({ onNavigateToDoc, onNavigateToGroup, onNavigateT
       )}
 
       {!loading && !error && agents.length === 0 && (
-        <div className="flex flex-col items-center justify-center h-48 text-gray-400">
-          <span className="text-4xl mb-4">🤖</span>
-          <p className="text-sm">No agents found in workspace</p>
-          <p className="text-xs mt-1 text-gray-300">Run setup.sh to add the first agent</p>
+        <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+          <span className="text-5xl mb-4">🤖</span>
+          <p className="text-base font-medium text-gray-500 dark:text-gray-400 mb-1">No agents in this workspace yet</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 mb-6">Get started by creating your first agent or deploying a team</p>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="#"
+              onClick={(e) => { e.preventDefault(); document.querySelector<HTMLButtonElement>('[title="Add Agent with AI"]')?.click() }}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-sky-600 text-white rounded-lg hover:bg-sky-700 transition-colors text-sm font-medium"
+            >
+              ✨ Create Agent with AI
+            </a>
+            <a
+              href="/templates"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors text-sm font-medium"
+            >
+              📋 Deploy a Team from Templates
+            </a>
+          </div>
         </div>
       )}
 

--- a/SYSTEM/dashboard/client/src/pages/Communication.tsx
+++ b/SYSTEM/dashboard/client/src/pages/Communication.tsx
@@ -691,7 +691,7 @@ export default function Communication({ onNavigateToAgent, onNavigateToWorkflow,
                   {communities.length} channel{communities.length !== 1 ? 's' : ''}
                 </span>
               </h2>
-              <div className="grid gap-2.5 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+              <div className="grid gap-3 grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                 {sortedCommunities.map(channel => (
                   <ChannelGridCard key={`community-${channel.name}`} channel={channel} selectedTags={selectedTags} selectedAgents={selectedAgents} onManageTags={() => setTagManageTarget(channel)} onNavigateToAgent={onNavigateToAgent} onOpenChat={() => openChat(channel)} onDelete={() => handleDeleteChannel(channel)} unreadCount={unreadCounts[`community:${channel.name}`] || 0} />
                 ))}
@@ -706,7 +706,7 @@ export default function Communication({ onNavigateToAgent, onNavigateToWorkflow,
                   {groups.length} channel{groups.length !== 1 ? 's' : ''}
                 </span>
               </h2>
-              <div className="grid gap-2.5 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+              <div className="grid gap-3 grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                 {sortedGroups.map(channel => (
                   <ChannelGridCard key={`group-${channel.name}`} channel={channel} selectedTags={selectedTags} selectedAgents={selectedAgents} onManageTags={() => setTagManageTarget(channel)} onNavigateToAgent={onNavigateToAgent} onOpenChat={() => openChat(channel)} onDelete={() => handleDeleteChannel(channel)} unreadCount={unreadCounts[`group:${channel.name}`] || 0} />
                 ))}

--- a/SYSTEM/dashboard/client/src/pages/SkillsTest.tsx
+++ b/SYSTEM/dashboard/client/src/pages/SkillsTest.tsx
@@ -35,11 +35,9 @@ export function SkillsTest({ initialAgentId }: { initialAgentId?: string } = {})
     }
   }, [initialAgentId])
 
-  // Reload skills when agent changes
+  // Reload skills when agent changes (or on mount if no agents)
   useEffect(() => {
-    if (agentId) {
-      loadSkills()
-    }
+    loadSkills()
   }, [agentId])
 
   async function loadAgents() {
@@ -53,8 +51,6 @@ export function SkillsTest({ initialAgentId }: { initialAgentId?: string } = {})
       // Set default agent to first available, or reset if current agent isn't in this workspace
       if (agentIds.length > 0 && (!agentId || !agentIds.includes(agentId))) {
         setAgentId(agentIds[0])
-      } else if (agentIds.length === 0) {
-        setLoading(false)
       }
 
       // Compute skill usage across all agents
@@ -195,7 +191,8 @@ export function SkillsTest({ initialAgentId }: { initialAgentId?: string } = {})
       const query = searchQuery.toLowerCase()
       const matchesSearch =
         skill.name.toLowerCase().includes(query) ||
-        skill.description.toLowerCase().includes(query)
+        skill.description.toLowerCase().includes(query) ||
+        (skill.tags || []).some(t => t.toLowerCase().includes(query))
       if (!matchesSearch) return false
     }
 
@@ -313,14 +310,12 @@ export function SkillsTest({ initialAgentId }: { initialAgentId?: string } = {})
         </div>
 
         {availableAgents.length === 0 && !loading && (
-          <div className="flex flex-col items-center justify-center h-96 text-gray-400">
-            <span className="text-6xl mb-4">🤖</span>
-            <p className="text-lg font-medium mb-2">No Agents in Workspace</p>
-            <p className="text-sm text-gray-500">Create an agent to start assigning skills</p>
+          <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg text-sm text-amber-800 dark:text-amber-300">
+            No agents in workspace — browsing skill catalog. Create an agent to start assigning skills.
           </div>
         )}
 
-        {availableAgents.length > 0 && (
+        {(availableAgents.length > 0 || allSkills.length > 0) && (
           <>
         {/* Stats */}
         <div className="grid grid-cols-3 gap-4 mb-6">

--- a/SYSTEM/dashboard/client/src/pages/Templates.tsx
+++ b/SYSTEM/dashboard/client/src/pages/Templates.tsx
@@ -970,7 +970,7 @@ function TemplateCard({ template, onDelete, onApply, onClick, selected, selectio
         <p className="text-xs text-gray-500 mb-3 line-clamp-2">{template.description}</p>
       )}
 
-      <div className="flex items-center gap-2 text-xs text-gray-400 mb-2">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-400 mb-2">
         <span>{agentCount} agent{agentCount !== 1 ? 's' : ''}</span>
         {isOrg && communityCount > 0 && (
           <>
@@ -1180,8 +1180,17 @@ function TemplateDetailPanel({ template, onClose, onDelete, onApply, onEdit, onI
             <div className="space-y-2">
               {template.agents.map((agent, idx) => (
                 <div key={idx} className="bg-gray-50 rounded px-3 py-2 text-sm dark:bg-gray-900">
-                  <div className="font-mono text-sky-600">{agent.id}</div>
-                  <div className="text-gray-600">{agent.role}</div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-mono text-sky-600 dark:text-sky-400">{agent.id}</span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">{agent.role}</span>
+                  </div>
+                  {agent.skills && agent.skills.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {agent.skills.map((s: string) => (
+                        <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-700">{s}</span>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/SYSTEM/dashboard/client/src/pages/Workflows.tsx
+++ b/SYSTEM/dashboard/client/src/pages/Workflows.tsx
@@ -804,7 +804,7 @@ export default function Workflows({ onNavigateToAgent, onNavigateToGroup, onNavi
   const allTags = React.useMemo(() => {
     const tags = new Set<string>()
     workflows.forEach(w => {
-      w.targeting.tags.forEach(tag => tags.add(tag))
+      (w.targeting?.tags || []).forEach(tag => tags.add(tag))
     })
     return Array.from(tags).sort()
   }, [workflows])
@@ -1836,10 +1836,10 @@ function getWorkflowDeleteConsequences(workflows: Workflow[]): string[] {
     consequences.push(`${workflow.name} — ${workflow.scheduleHuman || workflow.schedule || 'Manual'}`)
     consequences.push(`  • ${workflow.participantCount} targeted agent${workflow.participantCount !== 1 ? 's' : ''}`)
     consequences.push(`  • WORKFLOWS/${workflow.id}.md will be removed`)
-    if (workflow.targeting.groups.length > 0) {
+    if (workflow.targeting?.groups?.length > 0) {
       consequences.push(`  • targets ${workflow.targeting.groups.length} group${workflow.targeting.groups.length !== 1 ? 's' : ''}`)
     }
-    if (workflow.targeting.communities.length > 0) {
+    if (workflow.targeting?.communities?.length > 0) {
       consequences.push(`  • targets ${workflow.targeting.communities.length} communit${workflow.targeting.communities.length !== 1 ? 'ies' : 'y'}`)
     }
   })

--- a/SYSTEM/dashboard/client/src/types.ts
+++ b/SYSTEM/dashboard/client/src/types.ts
@@ -25,6 +25,7 @@ export interface OpenClawSkill {
   requires?: SkillRequirements
   install?: SkillInstallOption[]
   homepage?: string     // Optional homepage URL
+  tags?: string[]       // Searchable tags
 }
 
 // API Response Types

--- a/SYSTEM/dashboard/server/lib/messages.ts
+++ b/SYSTEM/dashboard/server/lib/messages.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { WORKSPACE } from './workspace'
+import { getWorkspacePath } from './workspace'
 import { generateArchiveTitle } from './ai-generator'
 
 export interface Message {
@@ -19,12 +19,13 @@ interface MessageStore {
 // Format: 'community:name' or 'group:name' -> Message[]
 const messageStore: MessageStore = {}
 
-// Directory for persistent message storage
-const MESSAGES_DIR = path.join(WORKSPACE, 'SYSTEM', 'messages')
-
-// Ensure messages directory exists
-if (!fs.existsSync(MESSAGES_DIR)) {
-  fs.mkdirSync(MESSAGES_DIR, { recursive: true })
+// Directory for persistent message storage (dynamic, follows active workspace)
+function getMessagesDir(): string {
+  const dir = path.join(getWorkspacePath(), 'SYSTEM', 'messages')
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+  return dir
 }
 
 function getStoreKey(type: 'community' | 'group', name: string): string {
@@ -33,7 +34,7 @@ function getStoreKey(type: 'community' | 'group', name: string): string {
 
 function getMessageFile(type: 'community' | 'group', name: string): string {
   const subdir = type === 'community' ? 'communities' : 'groups'
-  const dir = path.join(MESSAGES_DIR, subdir)
+  const dir = path.join(getMessagesDir(), subdir)
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true })
   }
@@ -105,7 +106,7 @@ export function addMessage(
 
 function getArchiveFile(type: 'community' | 'group', name: string, timestamp: number): string {
   const subdir = type === 'community' ? 'communities' : 'groups'
-  const archiveDir = path.join(MESSAGES_DIR, subdir, 'archive')
+  const archiveDir = path.join(getMessagesDir(), subdir, 'archive')
   if (!fs.existsSync(archiveDir)) {
     fs.mkdirSync(archiveDir, { recursive: true })
   }
@@ -140,7 +141,7 @@ export function clearMessages(type: 'community' | 'group', name: string): { arch
 
 export async function getArchives(type: 'community' | 'group', name: string): Promise<Array<{ filename: string; timestamp: number; messageCount: number; title: string }>> {
   const subdir = type === 'community' ? 'communities' : 'groups'
-  const archiveDir = path.join(MESSAGES_DIR, subdir, 'archive')
+  const archiveDir = path.join(getMessagesDir(), subdir, 'archive')
   const safeName = name.replace(/[^a-z0-9_-]/gi, '_').toLowerCase()
 
   if (!fs.existsSync(archiveDir)) {
@@ -226,7 +227,7 @@ export async function getArchives(type: 'community' | 'group', name: string): Pr
 
 export function getArchivedMessages(type: 'community' | 'group', name: string, filename: string): Message[] {
   const subdir = type === 'community' ? 'communities' : 'groups'
-  const archiveDir = path.join(MESSAGES_DIR, subdir, 'archive')
+  const archiveDir = path.join(getMessagesDir(), subdir, 'archive')
   const filePath = path.join(archiveDir, filename)
 
   try {
@@ -242,7 +243,7 @@ export function getArchivedMessages(type: 'community' | 'group', name: string, f
 
 export function deleteArchivedMessages(type: 'community' | 'group', name: string, filename: string): boolean {
   const subdir = type === 'community' ? 'communities' : 'groups'
-  const archiveDir = path.join(MESSAGES_DIR, subdir, 'archive')
+  const archiveDir = path.join(getMessagesDir(), subdir, 'archive')
   const filePath = path.join(archiveDir, filename)
 
   try {

--- a/SYSTEM/dashboard/server/lib/skills.ts
+++ b/SYSTEM/dashboard/server/lib/skills.ts
@@ -208,18 +208,20 @@ function parseWorkspaceSkillFile(filePath: string, skillId: string): OpenClawSki
     const name = data.name || lines[0]?.replace(/^#\s*/, '') || skillId
     const description = data.description || lines.find(l => !l.startsWith('#'))?.trim() || 'Custom skill'
 
+    const openclawMeta = data.metadata?.openclaw || {}
+
     return {
       id: skillId, // Store directory name for deletion
       name,
       description,
-      emoji: data.emoji,
+      emoji: data.emoji || openclawMeta.emoji,
       filePath,
       bundled: false,
       source: 'workspace',
-      requires: data.requires,
-      install: data.install,
-      homepage: data.homepage,
-      tags: data.tags || []
+      requires: data.requires || openclawMeta.requires,
+      install: data.install || openclawMeta.install,
+      homepage: data.homepage || openclawMeta.homepage,
+      tags: data.tags || openclawMeta.tags || []
     }
   } catch (err) {
     console.error(`Failed to parse workspace skill ${filePath}:`, err)

--- a/SYSTEM/dashboard/server/lib/templates.ts
+++ b/SYSTEM/dashboard/server/lib/templates.ts
@@ -4,6 +4,7 @@ import { getSystemProviderKeys } from './dashboard-env'
 import Ajv from 'ajv'
 import { execSync } from 'child_process'
 import { getWorkspacePath, getAgentsDir, parseIdentity, listAgents, parseGroups, readWorkspaceFile, writeWorkspaceFile } from './workspace'
+import { setAgentSkills, getAgentSkills } from './skills'
 import { listWorkflows, createWorkflow } from './workflows'
 import { TEMPLATES_DIR, TEMPLATE_SCHEMAS_DIR } from './paths'
 import { validateAgentConfigSections } from './agent-config-validation'
@@ -589,6 +590,16 @@ ${template.author ? `- **Template Author:** ${template.author}` : ''}
       fs.writeFileSync(identityPath, identity, 'utf-8')
     }
 
+    // Assign skills from template if defined
+    if (sourceAgent.skills && Array.isArray(sourceAgent.skills) && sourceAgent.skills.length > 0) {
+      try {
+        setAgentSkills(targetAgentId, sourceAgent.skills)
+        console.log(`Assigned skills [${sourceAgent.skills.join(', ')}] to agent ${targetAgentId}`)
+      } catch (err) {
+        console.warn(`Failed to assign skills to ${targetAgentId}: ${err}`)
+      }
+    }
+
     return { ok: true, agentId: targetAgentId }
   } catch (err) {
     return { ok: false, error: String(err) }
@@ -655,7 +666,7 @@ export function createAgentTemplateFromAgent(
         name: identity.name || agentId,
         role: identity.creature || 'AI Agent',
         tags: identity.tags || [],
-        skills: []  // TODO: Extract from skills/ directory when implemented
+        skills: getAgentSkills(agentId)
       }],
       metadata: {
         aiPrompt,
@@ -795,7 +806,7 @@ export function createOrganizationTemplate(
         name: identity.name || agentInfo.id,
         role: identity.creature || 'AI Agent',
         tags: identity.tags || [],
-        skills: [],  // TODO: Extract from skills/ directory
+        skills: getAgentSkills(agentInfo.id),
         communities: agentCommunities.length > 0 ? agentCommunities : undefined,
         groups: agentGroups.length > 0 ? agentGroups : undefined
       }
@@ -958,7 +969,7 @@ export function importOrganizationTemplate(
             let content = fs.readFileSync(identityPath, 'utf-8')
             content = content.replace(
               /^-\s+\*\*Name:\*\*\s+.+$/m,
-              `- **Name:** ${targetAgentId}`
+              `- **Name:** ${templateAgent.name || targetAgentId}`
             )
             fs.writeFileSync(identityPath, content, 'utf-8')
           }
@@ -1386,7 +1397,7 @@ export function importOrganizationTemplate(
 
         for (const wf of template.workflows) {
           // Update targeting to use new agent IDs if prefix/suffix was applied
-          const newAgents = wf.targeting.agents.map(agentId => `${prefix}${agentId}${suffix}`)
+          const newAgents = (wf.targeting.agents || []).map(agentId => `${prefix}${agentId}${suffix}`)
 
           const existing = existingWorkflowMap.get(wf.name)
           if (existing) {
@@ -1495,6 +1506,21 @@ export function importOrganizationTemplate(
         } catch (err) {
           console.warn(`Failed to register agent ${agentId}: ${err}`)
           // Don't fail the import if registration fails - agent files are still created
+        }
+      }
+
+      // Step 7: Assign skills from template to agents in openclaw.json
+      for (const templateAgent of agentsToCreate) {
+        const skills = templateAgent.skills
+        if (skills && Array.isArray(skills) && skills.length > 0) {
+          const targetAgentId = `${prefix}${templateAgent.id}${suffix}`
+          try {
+            setAgentSkills(targetAgentId, skills)
+            console.log(`Assigned skills [${skills.join(', ')}] to agent ${targetAgentId}`)
+          } catch (err) {
+            console.warn(`Failed to assign skills to ${targetAgentId}: ${err}`)
+            // Non-fatal — agent files and registration still intact
+          }
         }
       }
 

--- a/SYSTEM/dashboard/server/lib/workflows.ts
+++ b/SYSTEM/dashboard/server/lib/workflows.ts
@@ -272,7 +272,12 @@ export function listWorkflowTemplates(): Workflow[] {
         description: data.description || '',
         schedule: data.schedule || '',
         enabled: false, // Templates are disabled by default
-        targeting: data.targeting || { communities: [], groups: [], tags: [], agents: [] },
+        targeting: {
+        communities: data.targeting?.communities || [],
+        groups: data.targeting?.groups || [],
+        tags: data.targeting?.tags || [],
+        agents: data.targeting?.agents || [],
+      },
         created: data.created || '',
         modified: data.modified || '',
         author: data.author || 'system',
@@ -308,7 +313,12 @@ export function getWorkflow(id: string): Workflow | null {
       description: data.description || '',
       schedule: data.schedule || '',
       enabled: data.enabled !== false, // Default to true
-      targeting: data.targeting || { communities: [], groups: [], tags: [], agents: [] },
+      targeting: {
+        communities: data.targeting?.communities || [],
+        groups: data.targeting?.groups || [],
+        tags: data.targeting?.tags || [],
+        agents: data.targeting?.agents || [],
+      },
       created: data.created || new Date().toISOString(),
       modified: data.modified || new Date().toISOString(),
       author: data.author || '',
@@ -336,9 +346,12 @@ export function createWorkflow(data: Partial<Workflow>): { success: boolean; id?
     }
 
     // Validate cron expression (semantic check beyond schema)
-    const cronValidation = validateCron(data.schedule!)
-    if (!cronValidation.valid) {
-      return { success: false, error: `Invalid cron expression: ${cronValidation.error}` }
+    // Allow empty or "manual" for on-demand workflows
+    if (data.schedule && data.schedule !== 'manual') {
+      const cronValidation = validateCron(data.schedule)
+      if (!cronValidation.valid) {
+        return { success: false, error: `Invalid cron expression: ${cronValidation.error}` }
+      }
     }
 
     // Schema validation passed — these fields are guaranteed present
@@ -358,7 +371,12 @@ export function createWorkflow(data: Partial<Workflow>): { success: boolean; id?
       description,
       schedule,
       enabled: data.enabled !== false,
-      targeting: data.targeting || { communities: [], groups: [], tags: [], agents: [] },
+      targeting: {
+        communities: data.targeting?.communities || [],
+        groups: data.targeting?.groups || [],
+        tags: data.targeting?.tags || [],
+        agents: data.targeting?.agents || [],
+      },
       created: now,
       modified: now,
       author: data.author || 'unknown',

--- a/SYSTEM/docs/BACKLOG.md
+++ b/SYSTEM/docs/BACKLOG.md
@@ -82,9 +82,19 @@
 - [x] **Workflow AI Generate** — button on Workflows page, NL → workflow definition → editor pre-filled
 - [x] **Bulk model change** — select agents → change model for all at once
 
-### P7: Community Rules & Workflow Sequencing
+### P7: Workflow v2 — Autonomous Multiagent Coordination
+> Full design: `docs/hacks/openclaw-hack-day-mar25/WORKFLOW_V2_DESIGN.md`
+
+- [ ] **Agent blocker surfacing + dynamic UI** — agents declare blockers, notifications render actionable UI (choice/approval/input), human or agents resolve inline (P0)
+- [ ] **Kickoff workflow in templates** — `once` type workflow with pre-built prompt, runs on template apply, eliminates manual "paste prompt to start" step (P0)
+- [ ] **Agent-to-agent direct messaging** — 1-1 messages between agents for dependency resolution, not just group broadcast (P1)
+- [ ] **Workflow progress tracking** — agents report progress %, aggregated per workflow, visible in Workflows page (P1)
+- [ ] **Workflow DAG + dependencies** — `depends_on` field, parallel execution, sequential gates, conditional triggers (P2)
+- [ ] **Monitor + completion workflows** — recurring status aggregation, auto-complete when all deps met (P2)
+- [ ] **Workflow DAG visualization** — Mermaid-style graph in Workflows page with status coloring (P3)
+
+### P8: Community Rules
 - [ ] **Community rules and constraints** — define reusable rules/constraints at community level, inherited by all groups
-- [ ] **Workflow sequencing/chaining** — workflows trigger other workflows, dependency graphs, sequential execution
 
 ## High Priority (UX) — Completed or In Progress
 - [x] **Activity metering loading state** — shimmer placeholder in cost column while metering data loads
@@ -101,8 +111,15 @@
 - [ ] **Clean-room CI hardening** — keep `SYSTEM/test.sh` deterministic, GitHub Actions trustworthy on `main`
 
 ## High Priority (Features)
+- [ ] **Markdown rendering in chat** — render markdown in 1-1 agent chat and group chat messages (both user and agent bubbles). Currently displays raw markdown as plain text.
 - [ ] **Agent/workflow logs filtering** — by agent or tag
 - [ ] **Workspace stats dashboard** — aggregate view with pause/disable
+
+### Skills Management
+- [ ] **Edit skill tags post-import** — add/remove tags on any skill from the Skills page
+- [ ] **Skills select/select-all + bulk ops** — select mode with bulk add tags, bulk delete skills
+- [ ] **Skill tag filtering** — filter skills by tag (like agent tag filtering)
+- [ ] **Skills publish to SkillsHub** — package and publish workspace skills to GitHub/registry
 
 ## Medium Priority
 - [ ] Template tag filtering

--- a/SYSTEM/docs/hacks/README.md
+++ b/SYSTEM/docs/hacks/README.md
@@ -1,0 +1,7 @@
+# Hackathons
+
+Each subdirectory contains planning docs, presentations, and artifacts for a hackathon.
+
+| Hack | Date | Event | Status |
+|------|------|-------|--------|
+| [openclaw-hack-day-mar25](openclaw-hack-day-mar25/) | 2026-03-25 | OpenClaw Hack Day w/ OpenAI Codex | In Progress |

--- a/SYSTEM/docs/hacks/openclaw-hack-day-mar25/PLAN.md
+++ b/SYSTEM/docs/hacks/openclaw-hack-day-mar25/PLAN.md
@@ -1,0 +1,196 @@
+# OpenClaw Hack Day — March 25, 2026
+
+> **Event:** [The Agent Toolkit — OpenClaw Hack Day w/ OpenAI Codex](https://luma.com/openclaw-hack-day-mar25-2026?tk=yAFIM0)
+> **Goal:** Create weave-cli skills for OpenClaw + publish to SkillsHub + ClawMax "RAG Team" template
+> **Branch:** `hackathon/openclaw-hack-day-mar25`
+> **Deadline:** EOD March 25 (working MVP before 1pm, iterate until deadline)
+
+## Strategy
+
+Build OpenClaw skills that make any agent a weave-cli expert — able to plan, build, and operate multimodal RAG solutions end-to-end. Package as a ClawMax "RAG Team" template with parallel agent workflows.
+
+**Key repos:**
+- `clawmax` — dashboard, skills, templates
+- `weave-cli` — the RAG CLI being skilled
+- `auctionsmax-ai` — reference implementation to model after
+
+## Skill Architecture
+
+Split weave-cli capabilities into **5 focused skills** so agents can specialize and run in parallel:
+
+| # | Skill ID | Scope | Parallel? |
+|---|----------|-------|-----------|
+| 1 | `weave-setup` | Install, config, doctor, .env, VDB selection | Sequential (first) |
+| 2 | `weave-ingest` | Collections, schemas, chunking, pipeline ingest, backup | Yes |
+| 3 | `weave-search` | Queries, agents (RAG/QA/summarize), search tuning | Yes |
+| 4 | `weave-eval` | Datasets, evaluators, benchmarks, result analysis | Yes (after ingest) |
+| 5 | `weave-stack` | Stack init/up/down, k8s/podman, dashboard, day-2 ops | Yes |
+
+Plus one **orchestrator skill:**
+
+| # | Skill ID | Scope |
+|---|----------|-------|
+| 6 | `weave-planner` | End-to-end RAG lifecycle planning, agent coordination, user requirements gathering |
+
+**Publishing:** All skills published to [SkillsHub (weave-cli-skills)](https://github.com/Maximilien-ai/weave-cli-skills) for community use.
+
+### Skill Interconnection & Parallelism
+
+```mermaid
+graph TD
+    U["User Requirements"] --> P["weave-planner"]
+    P -->|"1. sequential"| S["weave-setup"]
+    S -->|"config ready"| FORK{"parallel fork"}
+
+    FORK -->|"2a. N agents"| I["weave-ingest"]
+    FORK -->|"2b. concurrent"| SR["weave-search"]
+
+    I -->|"data ready"| E["weave-eval"]
+    SR -->|"queries ready"| E
+
+    E -->|"results good?"| DECIDE{"user decides"}
+    DECIDE -->|"iterate"| I
+    DECIDE -->|"ship it"| ST["weave-stack"]
+
+    ST -->|"deployed"| PROD["Production RAG"]
+
+    style P fill:#f9f,stroke:#333
+    style S fill:#bbf,stroke:#333
+    style I fill:#bfb,stroke:#333
+    style SR fill:#bfb,stroke:#333
+    style E fill:#fbf,stroke:#333
+    style ST fill:#ffb,stroke:#333
+```
+
+**Scaling rules:**
+- `weave-setup` — 1 agent, sequential gate (runs first)
+- `weave-ingest` — **N agents** in parallel (split by document batches)
+- `weave-search` — **N agents** in parallel (concurrent with ingest after first batch)
+- `weave-eval` — **N agents** in parallel (after ingest completes)
+- `weave-stack` — 1 agent, sequential gate (runs last)
+- `weave-planner` — 1 agent, orchestrates full lifecycle
+
+## RAG Team Template
+
+Maps to ClawMax concepts:
+
+```
+Community: "RAG Team"
+  Group: "Planning"     — planner agent (weave-planner + weave-setup)
+  Group: "Data"         — ingest agents (weave-ingest)
+  Group: "Search & QA"  — search agents (weave-search)
+  Group: "Quality"      — eval agents (weave-eval)
+  Group: "Ops"          — stack/infra agents (weave-stack)
+
+Workflows:
+  1. "RAG Setup"        — sequential: planner gathers reqs → setup agent configures
+  2. "Data Pipeline"    — parallel: N ingest agents process documents
+  3. "Search Tuning"    — parallel with ingest: search agents test queries
+  4. "Eval Cycle"       — after ingest: eval agents run benchmarks
+  5. "Deploy"           — sequential: stack agent stands up infra
+  6. "Iterate"          — loop: eval results → tuning → re-eval
+```
+
+## Timeline — MVP-First Approach
+
+### Phase 1: Core Skills (target: 11:30am) — MUST HAVE
+
+- [x] **1a. Create skill scaffolding** — 6 skill directories with SKILL.md
+- [x] **1b. `weave-setup` skill** — full SKILL.md with weave doctor, config create, .env, VDB selection guidance
+- [x] **1c. `weave-ingest` skill** — collection create, schema suggest, chunking suggest, pipeline ingest, backup
+- [x] **1d. `weave-search` skill** — query, agents create/use, RAG/QA/summarize patterns
+- [x] **1e. `weave-eval` skill** — datasets, evaluators, eval run, benchmark, result interpretation
+- [x] **1f. `weave-stack` skill** — stack init/up/down/status, dashboard, day-2 ops
+- [x] **1g. `weave-planner` skill** — lifecycle orchestration, requirements gathering, plan generation
+
+### Phase 2: RAG Team Template (target: 12:30pm) — MUST HAVE
+
+- [x] **2a. Template JSON** — agents, communities, groups, workflows, parameters
+- [x] **2b. Agent IDENTITY/SOUL/TOOLS** — for each role (planner, data, search, eval, ops)
+- [x] **2c. Workflow definitions** — setup, ingest, search, eval, deploy, iterate
+- [x] **2d. Register template** — added to TEMPLATES/organizations/rag-team, 6 skills imported to workspace
+
+### Phase 3: MVP Test (target: 1:00pm) — MUST HAVE
+
+- [x] **3a. Deploy small RAG team** — applied template, 6 agents online, 6 workflows, skills wired
+- [x] **3d. Fix blockers** — fixed: targeting.agents undefined, manual schedule, cross-workspace messages, undefined tags, workflow targeting normalization, agent name expansion, skill emoji/tags parsing
+- [ ] **3b. Simple test case** — use auctionsmax-ai sample PDFs, 1 collection, basic eval
+- [ ] **3c. Verify e2e** — setup → ingest → search → eval → results
+
+### Phase 4: Scale & Polish (target: 3:00pm) — SHOULD HAVE
+
+- [ ] **4a. Scale test** — 2nd RAG team instance with more agents per role
+- [ ] **4b. Parallel workflows** — verify N ingest agents process data concurrently
+- [ ] **4c. Deeper evals** — multi-collection, multimodal, LLM judge
+- [ ] **4d. Day-2 ops** — backup, scaling guidance, security
+
+### Phase 5: Publish & Present (target: 5:00pm) — SHOULD HAVE
+
+- [ ] **5a. Publish skills to SkillsHub** — package and submit
+- [ ] **5b. Publish template to ClawMax** — tag release
+- [ ] **5c. Demo prep** — short demo script showing RAG team in action
+- [ ] **5d. Presentation** — slides or live demo walkthrough
+
+### Stretch Goals (if ahead of schedule)
+
+- [ ] **S1. MCP integration** — weave MCP server as skill tool
+- [ ] **S2. Embedding comparison workflow** — OSS vs OpenAI auto-benchmark
+- [ ] **S3. Cost estimation** — predict ingest/query costs before running
+- [ ] **S4. Template wizard** — generate RAG team from natural language description
+- [ ] **S5. Cross-VDB migration** — backup from one VDB, restore to another
+
+## Skill Content Reference
+
+### weave-cli Command Map → Skills
+
+| Command | Skill |
+|---------|-------|
+| `weave doctor`, `weave config *`, `weave vdb *`, `weave health` | weave-setup |
+| `weave collection create/list/show/delete`, `weave document *`, `weave pipeline ingest`, `weave schema suggest`, `weave chunking suggest`, `weave backup *` | weave-ingest |
+| `weave collection query`, `weave query`, `weave agents *`, `weave collection re-embed/compare` | weave-search |
+| `weave eval *`, `weave embeddings list` | weave-eval |
+| `weave stack *`, `weave serve`, `weave mcp *` | weave-stack |
+
+### Supported VDBs (10)
+Weaviate, Qdrant, Milvus, Chroma, Supabase, Neo4j, MongoDB Atlas, Pinecone, Elasticsearch, OpenSearch
+
+### Embedding Models
+- OpenAI: text-embedding-3-small (1536d), text-embedding-3-large (3072d)
+- OSS: sentence-transformers/all-mpnet-base-v2 (768d), all-MiniLM-L6-v2 (384d)
+- Ollama: nomic-embed-text (768d), mxbai-embed-large (1024d)
+
+### Agent Types (weave-cli built-in)
+- RAG (general, temp 0.7)
+- QA (precise, temp 0.3, strict mode)
+- Summarize (temp 0.5, markdown output)
+- Custom (user-defined)
+
+## Reference Implementation: auctionsmax-ai
+
+Pattern to follow:
+```
+config.yaml    → VDB config (Milvus default, collections defined)
+.env           → API keys (OPENAI_API_KEY, MILVUS_LOCAL_ADDRESS)
+weave-stack.yaml → k8s stack with MinIO for images
+weave-agents.yaml → Agent configurations
+data/          → Source documents (PDFs)
+evals/datasets/ → YAML test cases (5 basic, 3 multimodal, 5 image)
+tools/         → Shell scripts organized by concern
+frontend/      → Express + Socket.IO search UI
+```
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Skills too broad, agents confused | Split into 5 focused skills with clear boundaries |
+| weave-cli not installed on test agents | weave-setup skill includes install steps + doctor check |
+| No VDB running locally | Use mock VDB for testing, or Weaviate Cloud (free tier) |
+| Template too complex for testing | Start with 1-agent-per-role MVP, scale later |
+| Time crunch | Phase 1-3 are MVP, Phase 4-5 are bonus. Ship working small over broken big. |
+
+## Success Criteria
+
+1. **Minimum:** 5 skills created and importable in ClawMax, at least 1 agent can use them
+2. **Target:** RAG Team template deployed, small e2e test passing
+3. **Stretch:** Scaled team, published to SkillsHub, demo-ready

--- a/SYSTEM/docs/hacks/openclaw-hack-day-mar25/WORKFLOW_V2_DESIGN.md
+++ b/SYSTEM/docs/hacks/openclaw-hack-day-mar25/WORKFLOW_V2_DESIGN.md
@@ -1,0 +1,192 @@
+# Workflow v2 — Autonomous Multiagent Coordination
+
+> Designed at OpenClaw Hack Day, March 25, 2026
+> Based on real-world observation: RAG Team agents block waiting for input with no way to surface blockers or unblock each other.
+
+## Problem Statement
+
+Today's workflow system is **fire-and-forget cron**. Agents:
+- Block waiting for human input with no way to signal it
+- Can't communicate 1-1 with other agents to resolve dependencies
+- Don't know what other agents are doing or waiting on
+- Have no way to show progress or completion
+- Require human to manually poll each agent/group for status
+
+The result: a team of 6 agents mostly idle, waiting for someone to notice they're stuck.
+
+## Design: Five Pillars
+
+### 1. Agent Blocker Surfacing + Dynamic UI
+
+**The killer feature.** When an agent is blocked, it should:
+- Declare what it's blocked on (structured data, not just text)
+- Surface the blocker as a notification with an **actionable dynamic UI**
+- Allow human OR another agent to resolve the blocker inline
+
+```
+Notification: 🔴 data-engineer1 is blocked
+  "Need confirmation: Use Milvus local or Weaviate Cloud for ingestion?"
+
+  [Milvus Local]  [Weaviate Cloud]  [Let me specify...]
+```
+
+**Implementation:**
+- Agents emit structured blocker events: `{ type: "choice", options: [...] }` or `{ type: "approval", action: "..." }` or `{ type: "input", prompt: "..." }`
+- Notification center renders dynamic UI based on blocker type
+- Human clicks a button → response sent back to agent automatically
+- Other agents can also resolve blockers if they have the context
+
+**Blocker types:**
+| Type | UI | Example |
+|------|-----|---------|
+| `choice` | Radio buttons | "Which VDB?" → [Milvus] [Weaviate] [Qdrant] |
+| `approval` | Yes/No | "Proceed with ingestion of 2,636 docs?" → [Approve] [Reject] |
+| `input` | Text field | "Enter OpenAI API key" → [____] [Submit] |
+| `delegation` | Agent picker | "Need search-engineer to test queries" → [Assign] |
+| `waiting` | Status | "Waiting for data-pipeline to complete" → [Check Status] |
+
+### 2. Agent-to-Agent Direct Communication
+
+Agents need to talk to each other 1-1, not just via group broadcast:
+- Agent A can send a message directly to Agent B
+- Agent B receives it as a notification/prompt
+- Response flows back to Agent A
+
+**Use cases:**
+- Planner asks Data Engineer: "How many docs ingested so far?"
+- Eval Engineer tells Search Engineer: "Accuracy is low, try hybrid search"
+- Ops Engineer asks Planner: "Ready to deploy? Eval results look good."
+
+**Implementation:**
+- `POST /api/agents/{fromId}/message/{toId}` — send direct message
+- Recipient agent gets the message as next prompt via gateway
+- Conversation history stored per agent-pair
+
+### 3. Workflow Dependencies & Parallel Execution
+
+Workflows need a DAG (directed acyclic graph), not just a flat list:
+
+```yaml
+workflows:
+  - id: kickoff
+    type: once          # Run once on template apply
+    targets: planner
+
+  - id: rag-setup
+    depends_on: [kickoff]
+    targets: planner
+
+  - id: data-pipeline
+    depends_on: [rag-setup]    # Sequential gate
+    targets: data
+    parallel: true              # N agents run concurrently
+
+  - id: search-tuning
+    depends_on: [rag-setup]    # Same gate — parallel with data-pipeline
+    targets: search
+
+  - id: eval-cycle
+    depends_on: [data-pipeline]  # Waits for ingest to complete
+    targets: eval
+
+  - id: deploy
+    depends_on: [eval-cycle]     # Only after evals pass
+    targets: ops
+
+  - id: completion
+    depends_on: [deploy]
+    type: completion            # Marks the pipeline as done
+```
+
+**Visualization:** Mermaid-style DAG in the Workflows page showing:
+- Which workflows are pending/running/completed/blocked
+- Arrows showing dependencies
+- Color coding: green (done), blue (running), yellow (blocked), gray (pending)
+
+### 4. Workflow Progress Tracking
+
+Each workflow should report progress:
+
+```
+Data Pipeline: ████████░░ 80% (2,109 / 2,636 docs)
+  data-engineer1: 1,200 docs ingested
+  data-engineer2: 909 docs ingested
+
+Search Tuning: ██░░░░░░░░ 20%
+  search-engineer: Testing semantic mode (1/3 modes)
+
+Eval Cycle: ░░░░░░░░░░ 0% (waiting on Data Pipeline)
+```
+
+**Implementation:**
+- Agents report progress: `{ workflow: "data-pipeline", progress: 0.8, detail: "2109/2636 docs" }`
+- Workflow page shows aggregate progress bar
+- Progress feeds into dependency resolution (eval-cycle starts when data-pipeline hits 100%)
+
+### 5. Lifecycle Workflows (Kickoff, Monitor, Completion)
+
+Three special workflow types every org template should include:
+
+#### Kickoff Workflow
+- **Type:** `once` — runs exactly once when template is applied
+- **Target:** planner/lead agent
+- **Content:** Pre-built prompt with project context, team roster, and instructions
+- **Replaces:** The manual "paste a big prompt to get started" step
+
+#### Monitor Workflow
+- **Type:** `recurring` — runs on cron (e.g., every 30 min or hourly)
+- **Target:** all agents or planner
+- **Content:** "Report current status, blockers, and progress percentage"
+- **Output:** Aggregated status report in a dashboard widget
+
+#### Completion Workflow
+- **Type:** `conditional` — triggers when all dependencies are met
+- **Target:** planner + human
+- **Content:** Summary of what was accomplished, final metrics, next steps
+- **Action:** Mark the project/pipeline as complete
+
+## Template Integration
+
+Org templates should include:
+
+```json
+{
+  "lifecycle": {
+    "kickoff": {
+      "target": "planner",
+      "prompt": "You are the lead planner for a RAG project. Your team: ..."
+    },
+    "monitor": {
+      "schedule": "0 */1 * * *",
+      "target": "all"
+    },
+    "completion": {
+      "depends_on": ["deploy"],
+      "target": "planner"
+    }
+  }
+}
+```
+
+## Priority Order
+
+| Priority | Feature | Impact | Effort |
+|----------|---------|--------|--------|
+| P0 | Blocker surfacing + dynamic UI | Unblocks agents immediately | Medium |
+| P0 | Kickoff workflow in templates | Eliminates manual prompt step | Small |
+| P1 | Agent-to-agent messaging | Enables autonomous coordination | Medium |
+| P1 | Workflow progress tracking | Visibility into what's happening | Medium |
+| P2 | Workflow DAG + dependencies | Proper sequencing | Large |
+| P2 | Monitor + completion workflows | Full lifecycle automation | Medium |
+| P3 | DAG visualization in UI | Beautiful but not blocking | Medium |
+
+## Success Metric
+
+A RAG Team template that, after a single "kickoff" click:
+1. Planner creates the plan autonomously
+2. Agents execute in parallel where possible
+3. Blockers surface as notifications with one-click resolution
+4. Human sees progress without polling
+5. Pipeline completes and reports results
+
+Zero manual prompting after kickoff.

--- a/TEMPLATES/organizations/rag-team/agents/data-engineer/IDENTITY.md
+++ b/TEMPLATES/organizations/rag-team/agents/data-engineer/IDENTITY.md
@@ -1,0 +1,6 @@
+- **Name:** Data Engineer
+- **Role:** Data Ingestion Specialist
+- **Model:** openai/gpt-4o
+- **Skills:** weave-ingest
+
+You are a data ingestion specialist. You create collections, design schemas, configure chunking, run pipeline ingestion, and manage backups using weave-cli. You work in parallel with other data engineers to process large document sets efficiently.

--- a/TEMPLATES/organizations/rag-team/agents/data-engineer/SOUL.md
+++ b/TEMPLATES/organizations/rag-team/agents/data-engineer/SOUL.md
@@ -1,0 +1,8 @@
+You are thorough and reliability-focused. You:
+
+- Always dry-run before full ingestion
+- Use AI suggestions for schema and chunking decisions
+- Backup data before and after major operations
+- Report document counts and ingestion metrics
+- Handle errors gracefully — resume interrupted pipelines
+- Optimize batch sizes and worker counts for throughput

--- a/TEMPLATES/organizations/rag-team/agents/data-engineer/TOOLS.md
+++ b/TEMPLATES/organizations/rag-team/agents/data-engineer/TOOLS.md
@@ -1,0 +1,9 @@
+## Tools
+
+- `weave collection create <name>` — create collections
+- `weave schema suggest <path>` — AI schema recommendations
+- `weave chunking suggest <file>` — AI chunking recommendations
+- `weave pipeline ingest <source> --collection <name> --workers N` — batch ingestion
+- `weave document create/list/count/delete` — document management
+- `weave backup create/restore/validate` — data backup
+- `weave collection list/show/count` — collection info

--- a/TEMPLATES/organizations/rag-team/agents/eval-engineer/IDENTITY.md
+++ b/TEMPLATES/organizations/rag-team/agents/eval-engineer/IDENTITY.md
@@ -1,0 +1,6 @@
+- **Name:** Eval Engineer
+- **Role:** Quality & Evaluation Specialist
+- **Model:** openai/gpt-4o
+- **Skills:** weave-eval
+
+You are a quality and evaluation specialist. You create evaluation datasets, run benchmarks, analyze results, and recommend improvements. You are the quality gate — nothing ships to production without passing your evals.

--- a/TEMPLATES/organizations/rag-team/agents/eval-engineer/SOUL.md
+++ b/TEMPLATES/organizations/rag-team/agents/eval-engineer/SOUL.md
@@ -1,0 +1,8 @@
+You are rigorous and data-driven. You:
+
+- Create comprehensive test datasets covering edge cases
+- Define clear pass/fail thresholds before running evals
+- Run baseline evals first, then measure improvements
+- Provide specific, actionable recommendations when quality is low
+- Track quality trends across iterations
+- Know when quality is good enough to ship

--- a/TEMPLATES/organizations/rag-team/agents/eval-engineer/TOOLS.md
+++ b/TEMPLATES/organizations/rag-team/agents/eval-engineer/TOOLS.md
@@ -1,0 +1,9 @@
+## Tools
+
+- `weave eval run --agent <name> --dataset <name>` — run evaluation
+- `weave eval benchmark --agents <list> --dataset <name>` — benchmark multiple agents
+- `weave eval list` — list eval runs
+- `weave eval show <run-id>` — view results
+- `weave eval datasets list/create` — manage datasets
+- `weave eval list-evaluators` — available evaluators
+- `weave eval create-evaluator` — custom evaluator (LLM judge)

--- a/TEMPLATES/organizations/rag-team/agents/ops-engineer/IDENTITY.md
+++ b/TEMPLATES/organizations/rag-team/agents/ops-engineer/IDENTITY.md
@@ -1,0 +1,6 @@
+- **Name:** Ops Engineer
+- **Role:** Infrastructure & Deployment Specialist
+- **Model:** openai/gpt-4o
+- **Skills:** weave-stack
+
+You are an infrastructure and deployment specialist. You deploy RAG stacks to Kubernetes or Podman, manage the weave dashboard, handle monitoring, and operate day-2 concerns: backup schedules, scaling, security patching.

--- a/TEMPLATES/organizations/rag-team/agents/ops-engineer/SOUL.md
+++ b/TEMPLATES/organizations/rag-team/agents/ops-engineer/SOUL.md
@@ -1,0 +1,8 @@
+You are reliability-focused and operationally minded. You:
+
+- Always validate before deploying
+- Set up monitoring and health checks from day one
+- Automate backup schedules
+- Plan for scaling before it's needed
+- Keep security patches current
+- Document runbooks for common operations

--- a/TEMPLATES/organizations/rag-team/agents/ops-engineer/TOOLS.md
+++ b/TEMPLATES/organizations/rag-team/agents/ops-engineer/TOOLS.md
@@ -1,0 +1,12 @@
+## Tools
+
+- `weave stack init/validate` — initialize and validate stack config
+- `weave stack up --runtime <kind|minikube|eks|gke>` — deploy
+- `weave stack down` — shutdown
+- `weave stack status` — health check
+- `weave stack logs [component]` — view logs
+- `weave stack dashboard` — open web UI
+- `weave stack ingest/backup/collections` — stack operations
+- `weave stack kubectl` — direct kubectl access
+- `weave serve` — metrics server
+- `weave mcp list/call/test` — MCP integration

--- a/TEMPLATES/organizations/rag-team/agents/planner/IDENTITY.md
+++ b/TEMPLATES/organizations/rag-team/agents/planner/IDENTITY.md
@@ -1,0 +1,8 @@
+- **Name:** RAG Planner
+- **Role:** Solution Architect
+- **Model:** anthropic/claude-sonnet-4-20250514
+- **Skills:** weave-planner, weave-setup
+
+You are the lead architect for RAG solutions built with weave-cli. You gather requirements, design the solution architecture, create execution plans, and coordinate the team through the full RAG lifecycle.
+
+You work with a team: data engineers (ingestion), search engineers (queries/agents), eval engineers (quality), and ops engineers (deployment). Your job is to plan what they do and when.

--- a/TEMPLATES/organizations/rag-team/agents/planner/SOUL.md
+++ b/TEMPLATES/organizations/rag-team/agents/planner/SOUL.md
@@ -1,0 +1,9 @@
+You are methodical, pragmatic, and outcome-oriented. You:
+
+- Ask clarifying questions before making architecture decisions
+- Design for parallelism — identify what can run concurrently
+- Start with the simplest viable solution, then iterate
+- Track progress across all team members
+- Make data-driven recommendations based on eval results
+- Communicate clearly with the user about tradeoffs (cost, quality, speed)
+- Know when to iterate and when to ship

--- a/TEMPLATES/organizations/rag-team/agents/planner/TOOLS.md
+++ b/TEMPLATES/organizations/rag-team/agents/planner/TOOLS.md
@@ -1,0 +1,9 @@
+## Tools
+
+- `weave doctor` — verify system health
+- `weave config create --env` — initialize project configuration
+- `weave config show` — review current configuration
+- `weave vdb list` — list available vector databases
+- `weave vdb info <name>` — get VDB details for architecture decisions
+- `weave health check` — verify VDB connectivity
+- All weave-cli commands for diagnostic and planning purposes

--- a/TEMPLATES/organizations/rag-team/agents/search-engineer/IDENTITY.md
+++ b/TEMPLATES/organizations/rag-team/agents/search-engineer/IDENTITY.md
@@ -1,0 +1,6 @@
+- **Name:** Search Engineer
+- **Role:** Search & Agent Tuning Specialist
+- **Model:** openai/gpt-4o
+- **Skills:** weave-search
+
+You are a search and agent tuning specialist. You configure weave-cli AI agents (RAG, QA, summarize), test and optimize queries, compare embedding models, and tune search parameters for the best retrieval quality.

--- a/TEMPLATES/organizations/rag-team/agents/search-engineer/SOUL.md
+++ b/TEMPLATES/organizations/rag-team/agents/search-engineer/SOUL.md
@@ -1,0 +1,7 @@
+You are analytical and quality-driven. You:
+
+- Test multiple search modes (semantic, BM25, hybrid) systematically
+- Create agents matched to the use case (RAG for general, QA for precise)
+- Compare embedding models with side-by-side tests
+- Document query patterns that work well and those that don't
+- Collaborate with eval engineers to validate improvements

--- a/TEMPLATES/organizations/rag-team/agents/search-engineer/TOOLS.md
+++ b/TEMPLATES/organizations/rag-team/agents/search-engineer/TOOLS.md
@@ -1,0 +1,8 @@
+## Tools
+
+- `weave query <collection> <query>` — search collections
+- `weave collection query <collection> <query> --mode <semantic|bm25|hybrid>` — search modes
+- `weave agents create/list/show/edit/delete` — manage AI agents
+- `weave collection re-embed` — re-embed with different models
+- `weave collection compare` — compare embedding models
+- `weave embeddings list` — available embedding models

--- a/TEMPLATES/organizations/rag-team/template.json
+++ b/TEMPLATES/organizations/rag-team/template.json
@@ -1,0 +1,284 @@
+{
+  "name": "RAG Team",
+  "type": "organization",
+  "version": "1.0.0",
+  "description": "A multiagent team that builds end-to-end RAG solutions using weave-cli. Includes planner, data engineers, search engineers, eval engineers, and ops engineers working in parallel workflows across 10 vector databases.",
+  "author": "ClawMax Team",
+  "tags": [
+    "rag",
+    "weave-cli",
+    "vector-database",
+    "ai",
+    "multiagent"
+  ],
+  "parameters": [
+    {
+      "agentId": "data-engineer",
+      "label": "Number of Data Engineers",
+      "default": 2,
+      "min": 1,
+      "max": 10
+    },
+    {
+      "agentId": "search-engineer",
+      "label": "Number of Search Engineers",
+      "default": 1,
+      "min": 1,
+      "max": 5
+    },
+    {
+      "agentId": "eval-engineer",
+      "label": "Number of Eval Engineers",
+      "default": 1,
+      "min": 1,
+      "max": 5
+    }
+  ],
+  "agents": [
+    {
+      "id": "planner",
+      "name": "RAG Planner",
+      "role": "Solution Architect",
+      "tags": [
+        "planner",
+        "lead"
+      ],
+      "skills": [
+        "weave-planner",
+        "weave-setup"
+      ],
+      "communities": [
+        "RAG Team"
+      ],
+      "groups": [
+        "Planning",
+        "Status"
+      ]
+    },
+    {
+      "id": "data-engineer",
+      "name": "Data Engineer",
+      "role": "Data Ingestion Specialist",
+      "tags": [
+        "data",
+        "ingest"
+      ],
+      "skills": [
+        "weave-ingest"
+      ],
+      "communities": [
+        "RAG Team"
+      ],
+      "groups": [
+        "Data Pipeline",
+        "Status"
+      ]
+    },
+    {
+      "id": "search-engineer",
+      "name": "Search Engineer",
+      "role": "Search & Agent Tuning Specialist",
+      "tags": [
+        "search",
+        "qa"
+      ],
+      "skills": [
+        "weave-search"
+      ],
+      "communities": [
+        "RAG Team"
+      ],
+      "groups": [
+        "Search & QA",
+        "Status"
+      ]
+    },
+    {
+      "id": "eval-engineer",
+      "name": "Eval Engineer",
+      "role": "Quality & Evaluation Specialist",
+      "tags": [
+        "eval",
+        "quality"
+      ],
+      "skills": [
+        "weave-eval"
+      ],
+      "communities": [
+        "RAG Team"
+      ],
+      "groups": [
+        "Quality",
+        "Status"
+      ]
+    },
+    {
+      "id": "ops-engineer",
+      "name": "Ops Engineer",
+      "role": "Infrastructure & Deployment Specialist",
+      "tags": [
+        "ops",
+        "infra"
+      ],
+      "skills": [
+        "weave-stack"
+      ],
+      "communities": [
+        "RAG Team"
+      ],
+      "groups": [
+        "Ops",
+        "Status"
+      ]
+    }
+  ],
+  "communities": [
+    {
+      "name": "RAG Team",
+      "description": "Multiagent team building RAG solutions with weave-cli",
+      "channels": []
+    }
+  ],
+  "groups": [
+    {
+      "name": "Planning",
+      "community": "RAG Team",
+      "description": "Requirements gathering, architecture design, lifecycle coordination",
+      "channels": []
+    },
+    {
+      "name": "Data Pipeline",
+      "community": "RAG Team",
+      "description": "Collection creation, schema design, data ingestion, backup",
+      "channels": []
+    },
+    {
+      "name": "Search & QA",
+      "community": "RAG Team",
+      "description": "Query tuning, agent configuration, embedding comparison",
+      "channels": []
+    },
+    {
+      "name": "Quality",
+      "community": "RAG Team",
+      "description": "Eval datasets, benchmarks, quality gates, iteration recommendations",
+      "channels": []
+    },
+    {
+      "name": "Ops",
+      "community": "RAG Team",
+      "description": "Stack deployment, monitoring, day-2 operations",
+      "channels": []
+    },
+    {
+      "name": "Status",
+      "community": "RAG Team",
+      "description": "Cross-team status updates and coordination",
+      "channels": []
+    }
+  ],
+  "workflows": [
+    {
+      "id": "rag-setup",
+      "name": "RAG Setup",
+      "schedule": "manual",
+      "enabled": false,
+      "targeting": {
+        "tags": [
+          "planner"
+        ],
+        "communities": [],
+        "groups": [],
+        "agents": []
+      },
+      "executionMode": "automated",
+      "description": "Gather requirements, configure weave-cli, verify VDB health",
+      "content": "## RAG Setup\n\n1. Gather user requirements: What data sources? What query patterns? What quality bar?\n2. Recommend VDB based on requirements (run `weave vdb list` to show options)\n3. Run `weave config create --env` to initialize config.yaml and .env\n4. Run `weave doctor --fix` to verify all components healthy\n5. Run `weave health check` to confirm VDB connectivity\n6. Report setup status and recommended next steps to the Planning group"
+    },
+    {
+      "id": "data-pipeline",
+      "name": "Data Pipeline",
+      "schedule": "manual",
+      "enabled": false,
+      "targeting": {
+        "tags": [
+          "data"
+        ],
+        "communities": [],
+        "groups": [],
+        "agents": []
+      },
+      "executionMode": "automated",
+      "description": "Create collections, ingest documents in parallel batches, backup",
+      "content": "## Data Pipeline\n\n1. Run `weave schema suggest` on the source data directory to get AI schema recommendations\n2. Run `weave chunking suggest` on a sample file for chunk size guidance\n3. Create collections: `weave collection create <name>`\n4. Dry-run ingestion: `weave pipeline ingest <source> --collection <name> --dry-run`\n5. Run full ingestion with parallelism: `weave pipeline ingest <source> --collection <name> --workers 4 --batch-size 100`\n6. Verify counts: `weave collection count <name>` and `weave document list <name>`\n7. Backup: `weave backup create <collection> --compress`\n8. Report ingestion stats to Data Pipeline group"
+    },
+    {
+      "id": "search-tuning",
+      "name": "Search Tuning",
+      "schedule": "manual",
+      "enabled": false,
+      "targeting": {
+        "tags": [
+          "search"
+        ],
+        "communities": [],
+        "groups": [],
+        "agents": []
+      },
+      "executionMode": "automated",
+      "description": "Configure agents, test queries, compare search modes and embeddings",
+      "content": "## Search Tuning\n\n1. Create a RAG agent: `weave agents create rag-agent --type rag`\n2. Create a QA agent: `weave agents create qa-agent --type qa`\n3. Test representative queries across search modes: semantic, BM25, hybrid\n4. Compare results: `weave collection query <name> \"test query\" --top-k 10`\n5. If quality is low, try re-embedding: `weave collection re-embed <name> --new-embedding <model>`\n6. Compare models: `weave collection compare <original> <re-embedded> --query \"test\" --report comparison.md`\n7. Report best search configuration to Search & QA group"
+    },
+    {
+      "id": "eval-cycle",
+      "name": "Eval Cycle",
+      "schedule": "manual",
+      "enabled": false,
+      "targeting": {
+        "tags": [
+          "eval"
+        ],
+        "communities": [],
+        "groups": [],
+        "agents": []
+      },
+      "executionMode": "automated",
+      "description": "Run baseline evals, benchmark agents, report results and recommendations",
+      "content": "## Eval Cycle\n\n1. Create or verify baseline dataset (YAML with queries, expected answers, required concepts)\n2. Run baseline eval: `weave eval run --agent rag-agent --dataset baseline --collection <name>`\n3. Run benchmark across agent types: `weave eval benchmark --agents rag-agent,qa-agent --dataset baseline`\n4. Check scores: accuracy >= 0.70, citation >= 0.75, relevance >= 0.60\n5. If below threshold, recommend specific changes:\n   - Low relevance: try hybrid search or different embedding model\n   - Low accuracy: switch to QA agent with lower temperature\n   - Low citation: enable strict mode with must_cite\n6. Report results and recommendations to Quality group"
+    },
+    {
+      "id": "deploy",
+      "name": "Deploy",
+      "schedule": "manual",
+      "enabled": false,
+      "targeting": {
+        "tags": [
+          "ops"
+        ],
+        "communities": [],
+        "groups": [],
+        "agents": []
+      },
+      "executionMode": "automated",
+      "description": "Initialize stack, deploy to k8s/podman, verify health, set up monitoring",
+      "content": "## Deploy\n\n1. Initialize stack config: `weave stack init`\n2. Validate: `weave stack validate`\n3. Deploy: `weave stack up --runtime kind` (local) or `--runtime eks` (cloud)\n4. Verify health: `weave stack status`\n5. Ingest data into stack: `weave stack ingest <source> --collection <name>`\n6. Open dashboard: `weave stack dashboard`\n7. Set up monitoring: `weave serve --metrics-port 9090`\n8. Configure backup schedule\n9. Report deployment status to Ops group"
+    },
+    {
+      "id": "daily-status",
+      "name": "Daily Status",
+      "schedule": "0 9 * * 1-5",
+      "enabled": true,
+      "targeting": {
+        "groups": [
+          "Status"
+        ],
+        "communities": [],
+        "tags": [],
+        "agents": []
+      },
+      "executionMode": "automated",
+      "description": "Daily status check \u2014 each agent reports progress in their area",
+      "content": "## Daily Status\n\nReport your current status to the team:\n1. What did you accomplish since last check-in?\n2. What are you working on now?\n3. Any blockers or issues that need attention?\n4. Estimated progress toward your current objective (%)?\n\nKeep it brief \u2014 2-3 sentences per item."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Work from [OpenClaw Hack Day — March 25, 2026](https://luma.com/openclaw-hack-day-mar25-2026?tk=yAFIM0). Built weave-cli skills for OpenClaw agents and a RAG Team organization template for ClawMax.

### Skills (in [weave-cli-skills](https://github.com/Maximilien-ai/weave-cli-skills) repo)
- 6 skills: `weave-setup`, `weave-ingest`, `weave-search`, `weave-eval`, `weave-stack`, `weave-planner`
- Each with SKILL.md, index.ts, tags, emojis, brew + go install options

### RAG Team Template
- 5 agent roles: planner, data engineer (scalable), search engineer, eval engineer, ops engineer
- 6 groups: Planning, Data Pipeline, Search & QA, Quality, Ops, Status
- 6 workflows with detailed weave-cli instructions (5 manual + 1 daily cron)
- Parameterized scaling for data/search/eval engineers

### Dashboard Features
- **Skills wired on template apply** — `setAgentSkills()` in both agent and org template import
- **Skills per agent in template UI** — green badges in detail dialog and apply modal
- **Markdown rendering in chat** — user messages now render markdown (1-1, group, standalone)
- **Skill tags** — display, search, and filter by tags
- **Empty state improvements** — Agents page shows "Create with AI" / "Deploy from Templates" buttons

### Bug Fixes
- Template workflow import: guard `targeting.agents` undefined
- Workflow `"manual"` schedule accepted (was failing cron validation)
- Workflow targeting normalization (communities/groups/tags/agents always arrays)
- Cross-workspace message bleed (messages now scoped to active workspace)
- Agent tags undefined crash on load
- Skill metadata.openclaw parsing for workspace-imported skills
- Template card stats wrap on narrow cards
- Communication card widths (names no longer truncate)
- Unread badge scoped to current workspace channels
- Skills page visible when workspace has no agents

### Docs
- Hackathon plan with mermaid skill architecture diagram
- **Workflow v2 design** — autonomous multiagent coordination (blocker surfacing, agent-to-agent messaging, DAG dependencies, progress tracking, lifecycle workflows)
- Skills management backlog items
- Markdown chat rendering backlog item

## Test plan
- [x] TypeScript compiles clean
- [x] RAG Team template applies successfully (6 agents, 6 workflows, skills wired)
- [x] Skills page shows all 58 skills with tags/emojis on empty workspace
- [x] Template detail and apply modals show skills per agent
- [x] Chat messages render markdown for both user and agent
- [x] Workflow page loads without crashes (targeting normalization)
- [ ] Run full test suite after server restart (test.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)