### PR TITLE
fix: BYPASS_OAUTH login page shows OAuth error

### DIFF
--- a/SYSTEM/dashboard/server/lib/github-auth.ts
+++ b/SYSTEM/dashboard/server/lib/github-auth.ts
@@ -278,6 +278,12 @@ export function createAuthRouter(): Router {
   // GET /api/auth/me — get current user
   router.get('/me', (req, res) => {
     res.setHeader('Cache-Control', 'no-store')
+    if (process.env.BYPASS_OAUTH === 'true' || process.env.DASHBOARD_AUTH_DISABLED === 'true') {
+      return res.json({
+        authenticated: true,
+        user: { id: 0, login: 'local', name: 'Local User', avatar: '' },
+      })
+    }
     const session = getSessionFromRequest(req)
     if (!session) {
       return res.json({ authenticated: false })


### PR DESCRIPTION
## Summary
- `/api/auth/me` was ignoring `BYPASS_OAUTH=true` and always returning `authenticated: false` when no session cookie existed
- The login page checks `authenticated` to decide whether to show the "GitHub OAuth not configured" error instead of granting access
- Fix: return `authenticated: true` with a local user when bypass is enabled

## Test plan
- [ ] Set `BYPASS_OAUTH=true` in `SYSTEM/dashboard/.env`
- [ ] Restart dashboard — should go directly to dashboard without hitting the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)