### PR TITLE
Fix #33: Branch protection for main

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,37 @@
+# Branch Protection: `main`
+
+Branch protection rules are enforced via the GitHub API (not repo rulesets).
+
+## Active Rules
+
+### Required Pull Request Reviews
+- **Minimum approving reviews:** 1
+- **Dismiss stale reviews on push:** Yes
+- **Require code owner reviews:** No
+
+### Required Status Checks
+- **Strict mode:** Yes (branch must be up-to-date with `main` before merge)
+- **Required checks:** `test` (from `.github/workflows/ci.yml`)
+
+### Other Settings
+- **Enforce admins:** No (admins can bypass in emergencies)
+- **Allow force pushes:** No
+- **Allow deletions:** No
+- **Require signed commits:** Not yet (consider enabling later)
+
+## Implications
+- No direct pushes to `main` — all changes go through PRs
+- CI must pass before merge
+- At least one reviewer must approve
+- Stale approvals are dismissed when new commits are pushed
+
+## Modifying These Rules
+Use the GitHub API or repository Settings → Branches → `main`.
+
+```bash
+# View current protection
+gh api repos/Maximilien-ai/clawmax/branches/main/protection
+
+# Update (see GitHub docs for payload schema)
+gh api repos/Maximilien-ai/clawmax/branches/main/protection --method PUT --input payload.json
+```


### PR DESCRIPTION
## Changes

Applied branch protection rules to `main` via the GitHub API:

- ✅ **Require PR reviews:** 1 approving review before merge
- ✅ **Require CI status checks:** `test` job must pass
- ✅ **Strict mode:** Branch must be up-to-date before merge
- ✅ **Dismiss stale reviews:** New pushes invalidate old approvals
- ✅ **No direct pushes:** All changes go through PRs
- ✅ **No force pushes or deletions**

Also adds `.github/BRANCH_PROTECTION.md` documenting the rules and how to modify them.

### Not included (consider later)
- Require signed commits (needs team GPG key setup)
- Enforce on admins (left off for emergency bypass)

Closes #33