### PR TITLE
feat: ClawMax Dev Team template — self-managing dev team

### DIFF
--- a/TEMPLATES/organizations/clawmax-dev-team/TEMPLATE.md
+++ b/TEMPLATES/organizations/clawmax-dev-team/TEMPLATE.md
@@ -1,0 +1,41 @@
+---
+name: ClawMax Dev Team
+type: organization
+version: 1.0.0
+category: technical
+description: Self-managing development team. Agents triage issues, review PRs, run tests, and prepare releases.
+author: ClawMax Team
+tags: [dev-team, self-management, github, ci-cd]
+---
+
+# ClawMax Dev Team
+
+**Purpose:** Autonomous dev team that manages a GitHub repo — triage issues, review PRs, run tests, prepare releases.
+
+## Agents
+- **dev-lead**: Architecture decisions, PR approvals, sprint planning
+- **qa-engineer**: Test execution, coverage reporting, failure tracking
+- **github-triage**: Issue labeling, priority assignment, stale issue detection
+- **release-engineer**: Changelogs, version tags, release notes
+
+## Workflow DAG
+```
+dev-team-kickoff
+  → issue-triage (daily 9am)
+  → test-run (daily 10am)
+    → pr-review (manual, after triage)
+      → release-prep (manual, after PR review + tests)
+```
+
+## Defaults
+- GitHub repo: Maximilien-ai/clawmax
+- Main branch: main
+- Test command: ./SYSTEM/test.sh
+- Release prefix: v
+
+## Groups
+- **Dev Status**: Daily standups
+- **Code Review**: PR discussions
+- **Testing**: Test results and QA
+- **Triage**: Issue management
+- **Release**: Release planning and deployment

--- a/TEMPLATES/organizations/clawmax-dev-team/template.json
+++ b/TEMPLATES/organizations/clawmax-dev-team/template.json
@@ -1,0 +1,174 @@
+{
+  "name": "ClawMax Dev Team",
+  "type": "organization",
+  "version": "1.0.0",
+  "category": "technical",
+  "description": "Self-managing development team for ClawMax. Agents triage issues, review PRs, run tests, and prepare releases. Pre-configured for the ClawMax repo with sensible defaults.",
+  "author": "ClawMax Team",
+  "tags": [
+    "dev-team",
+    "self-management",
+    "github",
+    "ci-cd"
+  ],
+  "agents": [
+    {
+      "id": "dev-lead",
+      "name": "Dev Lead",
+      "role": "Development lead — coordinates the team, reviews architecture decisions, approves PRs, manages releases. You are the technical decision-maker for the ClawMax project.",
+      "tags": ["lead", "dev", "architecture"],
+      "skills": ["github", "gh-issues", "workspace-ls"],
+      "communities": ["Dev Team"],
+      "groups": ["Dev Status", "Code Review", "Release"]
+    },
+    {
+      "id": "qa-engineer",
+      "name": "QA Engineer",
+      "role": "Quality assurance — runs test suites, reports failures, verifies fixes, maintains test coverage. You ensure every change passes tests before merge.",
+      "tags": ["qa", "testing"],
+      "skills": ["github", "gh-issues", "workspace-ls"],
+      "communities": ["Dev Team"],
+      "groups": ["Dev Status", "Code Review", "Testing"]
+    },
+    {
+      "id": "github-triage",
+      "name": "GitHub Triage",
+      "role": "Issue and PR triage — labels new issues, assigns priority, routes to the right team member, ensures nothing falls through the cracks. You are the first responder for all GitHub activity.",
+      "tags": ["triage", "github", "issues"],
+      "skills": ["github", "gh-issues", "workspace-ls"],
+      "communities": ["Dev Team"],
+      "groups": ["Dev Status", "Triage"]
+    },
+    {
+      "id": "release-engineer",
+      "name": "Release Engineer",
+      "role": "Release management — prepares changelogs, tags releases, verifies builds, updates version numbers. You ensure smooth, documented releases.",
+      "tags": ["release", "ci-cd", "deploy"],
+      "skills": ["github", "gh-issues", "workspace-ls"],
+      "communities": ["Dev Team"],
+      "groups": ["Dev Status", "Release"]
+    }
+  ],
+  "communities": [
+    {
+      "name": "Dev Team",
+      "description": "ClawMax development team coordination"
+    }
+  ],
+  "groups": [
+    {
+      "name": "Dev Status",
+      "description": "Daily standups and status updates",
+      "community": "Dev Team"
+    },
+    {
+      "name": "Code Review",
+      "description": "PR reviews and code discussions",
+      "community": "Dev Team"
+    },
+    {
+      "name": "Testing",
+      "description": "Test results, coverage reports, QA updates",
+      "community": "Dev Team"
+    },
+    {
+      "name": "Triage",
+      "description": "Issue triage, bug reports, feature requests",
+      "community": "Dev Team"
+    },
+    {
+      "name": "Release",
+      "description": "Release planning, changelogs, deployment",
+      "community": "Dev Team"
+    }
+  ],
+  "workflows": [
+    {
+      "id": "dev-team-kickoff",
+      "name": "Dev Team Kickoff",
+      "description": "Initialize the dev team and set up GitHub coordination",
+      "schedule": "manual",
+      "enabled": true,
+      "executionMode": "managed",
+      "owner": "dev-lead",
+      "type": "once",
+      "targeting": {
+        "communities": [],
+        "groups": [],
+        "tags": [],
+        "agents": ["dev-lead", "qa-engineer", "github-triage", "release-engineer"]
+      },
+      "content": "# Dev Team Kickoff\n\nYou are the Dev Lead. Your team just came online.\n\n## Project Configuration\n> **Customize before applying:**\n\n- **GitHub repo:** [Maximilien-ai/clawmax]\n- **Main branch:** [main]\n- **Test command:** [./SYSTEM/test.sh]\n- **Release prefix:** [v]\n- **Sprint duration:** [1 week]\n\n## Your Tasks\n1. Introduce yourself in the Dev Team community\n2. Review the current state of the GitHub repo (open issues, PRs, recent commits)\n3. Assign initial responsibilities:\n   - GitHub Triage: scan and label all open issues\n   - QA Engineer: run the test suite and report results\n   - Release Engineer: check the latest tag and pending changes\n4. Set the sprint goal based on open high-priority issues\n5. Post the sprint plan to Dev Status group\n\n## GitHub Coordination\nUse the configured repo for all work.\n\n- Create GitHub issues for tasks and assignments\n- Push code changes to branches\n- Open PRs for review\n- Track progress via issue comments"
+    },
+    {
+      "id": "issue-triage",
+      "name": "Issue Triage",
+      "description": "Scan and triage new GitHub issues daily",
+      "schedule": "0 9 * * *",
+      "enabled": true,
+      "executionMode": "automated",
+      "type": "recurring",
+      "dependsOn": ["dev-team-kickoff"],
+      "targeting": {
+        "communities": [],
+        "groups": ["Triage"],
+        "tags": [],
+        "agents": ["github-triage"]
+      },
+      "content": "# Daily Issue Triage\n\n1. Check the GitHub repo for new issues since last triage\n2. For each new issue:\n   - Add appropriate labels (bug, feature, enhancement, documentation)\n   - Set priority (high-priority, medium-priority, low-priority)\n   - Assign to the right team member based on content\n3. Check for stale issues (no activity in 7+ days) and ping assignees\n4. Post triage summary to Triage group\n\n## GitHub Coordination\nUse the configured repo for all work."
+    },
+    {
+      "id": "test-run",
+      "name": "Test Run",
+      "description": "Run test suite and report results",
+      "schedule": "0 10 * * *",
+      "enabled": true,
+      "executionMode": "automated",
+      "type": "recurring",
+      "dependsOn": ["dev-team-kickoff"],
+      "targeting": {
+        "communities": [],
+        "groups": ["Testing"],
+        "tags": [],
+        "agents": ["qa-engineer"]
+      },
+      "content": "# Daily Test Run\n\n1. Pull the latest code from the main branch\n2. Run the full test suite using the configured test command\n3. Report results:\n   - Total tests, passed, failed, warnings\n   - Any new failures since last run\n   - Test duration\n4. If failures found:\n   - Create or update GitHub issues for each failure\n   - Tag with 'bug' and 'test-failure' labels\n   - Assign to the dev-lead for triage\n5. Post test summary to Testing group\n\n## GitHub Coordination\nUse the configured repo for all work."
+    },
+    {
+      "id": "pr-review",
+      "name": "PR Review",
+      "description": "Review open pull requests",
+      "schedule": "manual",
+      "enabled": true,
+      "executionMode": "managed",
+      "owner": "dev-lead",
+      "type": "recurring",
+      "dependsOn": ["issue-triage"],
+      "targeting": {
+        "communities": [],
+        "groups": ["Code Review"],
+        "tags": [],
+        "agents": ["dev-lead", "qa-engineer"]
+      },
+      "content": "# PR Review Session\n\n## Dev Lead Tasks\n1. List all open PRs in the GitHub repo\n2. For each PR:\n   - Review the changes and description\n   - Check if tests pass\n   - Leave review comments or approve\n3. Merge approved PRs\n\n## QA Engineer Tasks\n1. For each open PR:\n   - Check if CI passes\n   - Review test coverage\n   - Flag any missing tests\n2. Post review notes to Code Review group\n\n## GitHub Coordination\nUse the configured repo for all work."
+    },
+    {
+      "id": "release-prep",
+      "name": "Release Prep",
+      "description": "Prepare and tag a new release",
+      "schedule": "manual",
+      "enabled": true,
+      "executionMode": "managed",
+      "owner": "release-engineer",
+      "type": "recurring",
+      "dependsOn": ["pr-review", "test-run"],
+      "targeting": {
+        "communities": [],
+        "groups": ["Release"],
+        "tags": [],
+        "agents": ["release-engineer", "dev-lead"]
+      },
+      "content": "# Release Preparation\n\n## Release Engineer Tasks\n1. Check the latest tag and list all commits since then\n2. Generate a changelog from commit messages\n3. Verify all tests pass on the latest commit\n4. Bump version number if needed\n5. Create the release tag\n6. Post release notes to Release group\n\n## Dev Lead Tasks\n1. Review the changelog for completeness\n2. Approve the release\n3. Announce in Dev Status group\n\n## GitHub Coordination\nUse the configured repo for all work."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- 4 agents: dev-lead, qa-engineer, github-triage, release-engineer
- 5 groups: Dev Status, Code Review, Testing, Triage, Release
- 5 DAG workflows: kickoff → triage + tests → PR review → release
- Pre-configured for Maximilien-ai/clawmax repo

## Test plan
- [ ] Template appears in Templates page
- [ ] Apply with defaults — all agents, groups, workflows created
- [ ] DAG view shows correct dependency chain
- [ ] Kickoff workflow runs with project context

Closes #65
