### PR TITLE
feat: persist structured workflow inputs in execution records

### DIFF
--- a/SYSTEM/dashboard/server/lib/workflows.ts
+++ b/SYSTEM/dashboard/server/lib/workflows.ts
@@ -83,6 +83,7 @@ export interface WorkflowExecution {
   triggeredBy?: string
   participants: WorkflowExecutionParticipant[]
   logs: string[]
+  inputs?: Record<string, string>  // Structured inputs parsed from workflow content
 }
 
 // Helper: Generate ID from name
@@ -772,7 +773,20 @@ export function triggerWorkflow(workflowId: string, options?: {
       status: 'pending' as const
     }))
 
-    // Create execution record with participants
+    // Parse structured inputs from workflow content (e.g., **Label:** value)
+    const inputs: Record<string, string> = {}
+    const content = workflow.content || ''
+    const fieldRegex = /^-\s+\*\*(.+?):\*\*\s+(.+)$/gm
+    let fieldMatch
+    while ((fieldMatch = fieldRegex.exec(content)) !== null) {
+      const label = fieldMatch[1].trim()
+      const value = fieldMatch[2].trim()
+      if (value && !value.startsWith('[')) {
+        inputs[label] = value
+      }
+    }
+
+    // Create execution record with participants and inputs
     const execution: WorkflowExecution = {
       id: executionId,
       workflowId,
@@ -780,7 +794,8 @@ export function triggerWorkflow(workflowId: string, options?: {
       status: 'running',
       triggerType: 'manual',
       participants: executionParticipants,
-      logs: [`Workflow triggered at ${new Date().toISOString()}`, `Targeting ${executionParticipants.length} agent(s)`]
+      logs: [`Workflow triggered at ${new Date().toISOString()}`, `Targeting ${executionParticipants.length} agent(s)`],
+      inputs: Object.keys(inputs).length > 0 ? inputs : undefined,
     }
 
     // Write execution file

--- a/SYSTEM/dashboard/server/routes/workflows.ts
+++ b/SYSTEM/dashboard/server/routes/workflows.ts
@@ -372,7 +372,8 @@ router.get('/:id/executions', (req, res) => {
       triggerType: exec.triggerType,
       participantCount: exec.participants.length,
       successCount: exec.participants.filter(p => p.status === 'completed').length,
-      failureCount: exec.participants.filter(p => p.status === 'failed').length
+      failureCount: exec.participants.filter(p => p.status === 'failed').length,
+      inputs: exec.inputs,
     }))
 
     res.json({
@@ -435,7 +436,8 @@ router.get('/:id/executions/archived', (req, res) => {
           triggerType: execution.triggerType,
           participantCount: execution.participants.length,
           successCount: execution.participants.filter((p: any) => p.status === 'completed').length,
-          failureCount: execution.participants.filter((p: any) => p.status === 'failed').length
+          failureCount: execution.participants.filter((p: any) => p.status === 'failed').length,
+          inputs: execution.inputs,
         })
       } catch (error) {
         console.error(`Error reading archived execution ${file}:`, error)


### PR DESCRIPTION
## Summary
- Parses `**Label:** value` fields from workflow content on trigger
- Stores as `inputs` map in execution JSON
- Exposed in execution list + detail API responses
- Dashboards can show "what started this run" without log parsing

## Test plan
- [ ] Trigger a workflow with configured fields (e.g., Research topic, GitHub repo)
- [ ] Check execution JSON has `inputs` field
- [ ] API `/api/workflows/:id/executions` returns inputs
- [ ] Placeholder values `[...]` are excluded

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)