### PR TITLE
fix: harden gateway diagnostics and budget scoping

### DIFF
--- a/SYSTEM/dashboard/client/src/components/AddAgentWizard.tsx
+++ b/SYSTEM/dashboard/client/src/components/AddAgentWizard.tsx
@@ -18,7 +18,7 @@ interface WizardProps {
   startWithAI?: boolean
 }
 
-type Step = 1 | 2 | 3 | 4 | 5
+type Step = 1 | 2 | 3 | 4
 
 interface FormState {
   name: string
@@ -274,8 +274,7 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
     1: nameOk && form.model.length > 0,
     2: true, // AI generation is optional
     3: true, // whatsapp is optional
-    4: true, // port/profile optional
-    5: false, // provision button handles this
+    4: false, // provision button handles this
   }
 
   async function generateWithAI() {
@@ -443,7 +442,7 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
   }
 
   async function createAgentNowFromAI() {
-    setStep(5)
+    setStep(4)
     await provision()
   }
 
@@ -472,7 +471,7 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
 
         {/* Step indicators */}
         <div className="px-6 pt-4 pb-2 flex items-center gap-2 shrink-0">
-          {([1, 2, 3, 4, 5] as Step[]).map(s => (
+          {([1, 2, 3, 4] as Step[]).map(s => (
             <React.Fragment key={s}>
               <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold transition-colors ${
                 s < step ? 'bg-sky-600 text-white' :
@@ -481,14 +480,14 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
               }`}>
                 {s < step ? '✓' : s}
               </div>
-              {s < 5 && <div className={`flex-1 h-0.5 rounded ${s < step ? 'bg-sky-400' : 'bg-gray-200'}`} />}
+              {s < 4 && <div className={`flex-1 h-0.5 rounded ${s < step ? 'bg-sky-400' : 'bg-gray-200'}`} />}
             </React.Fragment>
           ))}
         </div>
 
         {/* Step labels */}
         <div className="px-6 pb-3 flex justify-between shrink-0">
-          {['Identity', 'AI Agent', 'Channel', 'Deploy', 'Provision'].map((label, i) => (
+          {['Identity', 'AI Agent', 'Channel', 'Provision'].map((label, i) => (
             <span key={label} className={`text-xs ${step === i + 1 ? 'text-sky-600 font-medium' : 'text-gray-400'}`}>
               {label}
             </span>
@@ -796,7 +795,7 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
                       {provisioning ? 'Creating…' : validatingProvision ? 'Validating…' : 'Create Agent'}
                     </button>
                     <button
-                      onClick={() => setStep(3)}
+                      onClick={() => setStep(4)}
                       disabled={provisioning || validatingProvision}
                       className="px-4 py-2 text-sm rounded border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                     >
@@ -826,28 +825,8 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
             </div>
           )}
 
-          {/* Step 4: Deployment */}
+          {/* Step 4: Review + Provision */}
           {step === 4 && (
-            <div className="space-y-4">
-              <div>
-                <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Gateway port <span className="text-gray-400">(optional)</span></label>
-                <input
-                  type="number"
-                  value={form.port || ''}
-                  onChange={e => set('port', e.target.value ? parseInt(e.target.value, 10) : 0)}
-                  placeholder={String(suggested?.port ?? 18789)}
-                  className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-gray-700 rounded-md outline-none focus:border-sky-400 dark:focus:border-sky-600 font-mono bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
-                />
-                <p className="mt-1 text-xs text-gray-400">Suggested: <strong>{suggested?.port ?? '…'}</strong></p>
-              </div>
-              <div className="p-3 bg-sky-50 dark:bg-sky-900/20 border border-sky-200 dark:border-sky-800 rounded-lg text-xs text-sky-700 dark:text-sky-300">
-                State will be isolated under <code className="font-mono">~/.openclaw-{form.name || suggested?.id || 'name'}/</code> with its own gateway and credentials.
-              </div>
-            </div>
-          )}
-
-          {/* Step 5: Review + Provision */}
-          {step === 5 && (
             <div className="space-y-4">
               {!provisioning && !done && !provError && (
                 <>
@@ -907,7 +886,7 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
           </button>
 
           <div className="flex items-center gap-2">
-            {step < 5 && (
+            {step < 4 && (
               <button
                 onClick={() => setStep(s => (s + 1) as Step)}
                 disabled={!canNext[step]}
@@ -916,7 +895,7 @@ export default function AddAgentWizard({ onClose, onDone, defaultCloneFrom, star
                 Next
               </button>
             )}
-            {step === 5 && !done && (
+            {step === 4 && !done && (
               <button
                 onClick={provision}
                 disabled={provisioning || validatingProvision}

--- a/SYSTEM/dashboard/client/src/components/AgentStatusPanel.tsx
+++ b/SYSTEM/dashboard/client/src/components/AgentStatusPanel.tsx
@@ -9,6 +9,7 @@ interface Props {
 interface GatewayStatus {
   available: boolean
   port?: number
+  code?: string
   status?: {
     uptime?: number
     version?: string
@@ -111,6 +112,48 @@ export default function AgentStatusPanel({ agentId, agentName, onClose }: Props)
     )
   }
 
+  const statusCopy = (() => {
+    switch (gatewayStatus?.code) {
+      case 'gateway_not_configured':
+        return {
+          title: 'Gateway Not Configured',
+          detail: 'This agent does not currently have a gateway runtime attached.',
+          hint: 'Open Doctor to verify runtime configuration and gateway supervision for this instance.'
+        }
+      case 'gateway_auth_failed':
+        return {
+          title: 'Gateway Authentication Failed',
+          detail: 'The dashboard reached the agent gateway, but the runtime rejected the status request.',
+          hint: 'Open Doctor and check the runtime gateway credentials and agent registration state.'
+        }
+      case 'gateway_timeout':
+        return {
+          title: 'Gateway Timed Out',
+          detail: 'The runtime gateway did not answer the status probe in time.',
+          hint: 'Open Doctor to confirm the gateway is running and responsive in this runtime.'
+        }
+      case 'gateway_connection_error':
+      case 'gateway_connection_closed':
+        return {
+          title: 'Gateway Connection Failed',
+          detail: 'The dashboard could not maintain a connection to the agent gateway.',
+          hint: 'Open Doctor to inspect runtime connectivity and supervisor health for this instance.'
+        }
+      case 'gateway_status_error':
+        return {
+          title: 'Gateway Status Failed',
+          detail: 'The runtime gateway responded, but the status request itself failed.',
+          hint: 'Open Doctor and review runtime logs for the gateway process.'
+        }
+      default:
+        return {
+          title: 'Agent Chat Unavailable',
+          detail: gatewayStatus?.error || 'This agent cannot reach a healthy gateway runtime right now.',
+          hint: 'Open Doctor to verify gateway health and the runtime execution path for this instance.'
+        }
+    }
+  })()
+
   if (!gatewayStatus?.available) {
     return (
       <div className="fixed inset-y-0 right-0 z-50 w-full sm:w-[400px] bg-white dark:bg-gray-800 shadow-2xl flex flex-col">
@@ -121,13 +164,22 @@ export default function AgentStatusPanel({ agentId, agentName, onClose }: Props)
         <div className="flex-1 flex items-center justify-center px-6">
           <div className="text-center">
             <div className="text-6xl mb-4">⚠️</div>
-            <h3 className="text-lg font-semibold text-gray-700 mb-2 dark:text-gray-300">Agent Chat Unavailable</h3>
+            <h3 className="text-lg font-semibold text-gray-700 mb-2 dark:text-gray-300">{statusCopy.title}</h3>
             <p className="text-sm text-gray-500 mb-2">
-              {gatewayStatus?.error || 'Chat requires the gateway and API keys to be configured.'}
+              {statusCopy.detail}
             </p>
             <p className="text-xs text-gray-400 mb-3">
-              Run <code className="bg-gray-100 px-1 rounded dark:bg-gray-700">openclaw gateway start</code> and add API keys to <code className="bg-gray-100 px-1 rounded dark:bg-gray-700">.env</code>
+              {statusCopy.hint}
             </p>
+            <div className="flex items-center justify-center gap-2">
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent('open-doctor'))}
+                className="px-3 py-1.5 rounded-lg bg-amber-600 text-white text-sm font-medium hover:bg-amber-700 transition-colors"
+              >
+                Open Doctor
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/SYSTEM/dashboard/server/index.ts
+++ b/SYSTEM/dashboard/server/index.ts
@@ -230,7 +230,13 @@ app.get('/api/budget', protect, async (req, res) => {
       })
     }
     const workspaceId = typeof req.query.workspaceId === 'string' ? req.query.workspaceId : undefined
-    const status = await getBudgetStatus(workspaceId)
+    const session = getAuthenticatedSession(req)
+    const status = await getBudgetStatus(workspaceId, {
+      userId: session?.userId || null,
+      login: session?.login || null,
+      email: session?.email || null,
+      dashboardInstanceId: getRequestDashboardInstanceId(req),
+    })
     res.json({ enabled: true, ...status })
   } catch (err: any) {
     res.status(500).json({ error: err.message })

--- a/SYSTEM/dashboard/server/lib/budget.test.ts
+++ b/SYSTEM/dashboard/server/lib/budget.test.ts
@@ -14,6 +14,7 @@ import {
   checkBudgetBlock,
   validateAgentCostLimit,
 } from './budget'
+import { initOpikTracing, shutdownOpik } from './opik'
 import { resetWorkspaceManagerForTests } from './workspace-manager'
 
 const GREEN = '\x1b[32m'
@@ -102,12 +103,16 @@ async function run() {
   })
 
   await test('checkBudgetBlock returns workflow-specific message', () => {
+    process.env.OPIK_API_KEY = 'test-opik-key'
+    initOpikTracing()
     saveBudgetConfig({ limitUsd: 44, warningPct: 80, enforced: true, paused: true }, 'workspace-a')
     const message = checkBudgetBlock({ workspaceId: 'workspace-a', operation: 'workflow' })
     assert(message === 'Workflow blocked: workspace budget exceeded ($44.00 limit). Increase budget or disable enforcement to continue.', 'Expected workflow-specific budget message')
   })
 
   await test('checkBudgetBlock returns agent-specific message', () => {
+    process.env.OPIK_API_KEY = 'test-opik-key'
+    initOpikTracing()
     saveBudgetConfig({ limitUsd: 55, warningPct: 80, enforced: true, paused: true }, 'workspace-b')
     const message = checkBudgetBlock({ workspaceId: 'workspace-b', operation: 'agent' })
     assert(message === 'Agent interaction blocked: workspace budget exceeded ($55.00 limit). Increase budget or disable enforcement to continue.', 'Expected agent-specific budget message')
@@ -133,6 +138,7 @@ async function run() {
 
   if (typeof originalOpikApiKey === 'undefined') delete process.env.OPIK_API_KEY
   else process.env.OPIK_API_KEY = originalOpikApiKey
+  shutdownOpik()
 
   resetWorkspaceManagerForTests()
 

--- a/SYSTEM/dashboard/server/lib/budget.ts
+++ b/SYSTEM/dashboard/server/lib/budget.ts
@@ -7,7 +7,7 @@
 import fs from 'fs'
 import path from 'path'
 import { getWorkspacePath } from './workspace'
-import { getWorkspaceMetering } from './metering'
+import { getWorkspaceMetering, type MeteringViewer } from './metering'
 import { getWorkspaceManager } from './workspace-manager'
 import { isOpikEnabled } from './opik'
 
@@ -60,9 +60,9 @@ export function saveBudgetConfig(config: BudgetConfig, workspaceId?: string): vo
   fs.writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf-8')
 }
 
-export async function getBudgetStatus(workspaceId?: string): Promise<BudgetStatus> {
+export async function getBudgetStatus(workspaceId?: string, viewer?: MeteringViewer): Promise<BudgetStatus> {
   const config = loadBudgetConfig(workspaceId)
-  const metering = await getWorkspaceMetering(workspaceId)
+  const metering = await getWorkspaceMetering(workspaceId, viewer)
   const currentSpend = metering.estimatedCostUsd
 
   const usedPct = config.limitUsd > 0

--- a/SYSTEM/dashboard/server/lib/metering.ts
+++ b/SYSTEM/dashboard/server/lib/metering.ts
@@ -58,7 +58,7 @@ export interface WorkspaceMetering {
   period: string
 }
 
-interface MeteringViewer {
+export interface MeteringViewer {
   userId?: string | null
   login?: string | null
   email?: string | null

--- a/SYSTEM/dashboard/server/routes/logs.ts
+++ b/SYSTEM/dashboard/server/routes/logs.ts
@@ -21,6 +21,7 @@ router.get('/:id/status', async (req, res) => {
   if (!gatewayConfig) {
     return res.status(404).json({
       error: 'Gateway not configured for this agent',
+      code: 'gateway_not_configured',
       available: false
     })
   }
@@ -39,7 +40,7 @@ router.get('/:id/status', async (req, res) => {
 
     const timeout = setTimeout(() => {
       ws.close()
-      res.status(503).json({ error: 'Gateway timeout', available: false })
+      res.status(503).json({ error: 'Gateway timed out while reporting status', code: 'gateway_timeout', available: false })
       resolve()
     }, 10000)
 
@@ -103,7 +104,7 @@ router.get('/:id/status', async (req, res) => {
           } else {
             clearTimeout(timeout)
             ws.close()
-            res.status(401).json({ error: 'Authentication failed', available: false })
+            res.status(401).json({ error: 'Gateway authentication failed', code: 'gateway_auth_failed', available: false })
             resolve()
           }
           return
@@ -115,7 +116,7 @@ router.get('/:id/status', async (req, res) => {
           ws.close()
 
           if (message.error) {
-            res.status(500).json({ error: message.error.message || 'Status error', available: false })
+            res.status(500).json({ error: message.error.message || 'Gateway status request failed', code: 'gateway_status_error', available: false })
           } else {
             res.json({
               available: true,
@@ -132,14 +133,14 @@ router.get('/:id/status', async (req, res) => {
 
     ws.on('error', () => {
       clearTimeout(timeout)
-      res.status(503).json({ error: 'Gateway connection error', available: false })
+      res.status(503).json({ error: 'Gateway connection failed', code: 'gateway_connection_error', available: false })
       resolve()
     })
 
     ws.on('close', () => {
       clearTimeout(timeout)
       if (!res.headersSent) {
-        res.status(503).json({ error: 'Gateway connection closed', available: false })
+        res.status(503).json({ error: 'Gateway connection closed before status completed', code: 'gateway_connection_closed', available: false })
       }
       resolve()
     })


### PR DESCRIPTION
## Summary
- remove the customer-facing gateway/deploy step from create agent
- scope workspace budget to the current user, workspace, and dashboard instance
- classify agent gateway status failures and route users to Doctor instead of local-machine commands

## Validation
- npm run typecheck
- npx ts-node --transpileOnly server/lib/budget.test.ts
- npx ts-node --transpileOnly server/lib/metering.test.ts
- npx ts-node --transpileOnly server/lib/workspace-manager.test.ts
- npx ts-node --transpileOnly server/lib/integration-validation.test.ts