### PR TITLE
fix: filter streamed runtime warnings by line, not by chunk

### DIFF
--- a/SYSTEM/dashboard/server/lib/chat-normalization.ts
+++ b/SYSTEM/dashboard/server/lib/chat-normalization.ts
@@ -160,6 +160,65 @@ export function stripBenignChatRuntimeWarnings(content: string): string {
     .join('\n')
 }
 
+/**
+ * Line-buffered warning filter for a live stream.
+ *
+ * `stripBenignChatRuntimeWarnings` matches whole lines, but a stream arrives in arbitrary chunks: a
+ * boxed CLI warning routinely lands split across two of them, and neither half matches the line
+ * patterns, so both are forwarded. Observed in chat as a bare
+ * `│ ignored; remove it from plugins config) │` rendered as the agent's entire reply -- the real
+ * answer had been filtered out of the final text, so the client fell back to the streamed fragments.
+ *
+ * So: only ever hand complete lines to the filter, and hold the incomplete tail until its newline
+ * arrives. Newlines are preserved by slicing rather than split/join, because a filter that drops a
+ * separator silently joins a paragraph to the table that followed it.
+ *
+ * Every incomplete line is held, not just ones that look like a warning. An earlier version buffered
+ * only lines starting with a box-drawing character, on the theory that prose should never be
+ * delayed -- but that let every non-boxed warning through the moment it was split
+ * (`plugin runtime config.loadConfig() is deprecated`, `[provider-transport-fetch] ...`), which is
+ * the same bug in a narrower form. Correctness first: this is line-oriented CLI output, so the wait
+ * is bounded by the next newline.
+ */
+const MAX_HELD_LINE_CHARS = 8192
+
+export function createStreamingWarningFilter(): {
+  push: (chunk: string) => string
+  flush: () => string
+} {
+  let carry = ''
+  return {
+    push(chunk: string): string {
+      carry += chunk
+      const lastNewline = carry.lastIndexOf('\n')
+      if (lastNewline < 0) {
+        // No complete line yet. Release an absurdly long unterminated line rather than growing the
+        // buffer without bound: re-scanning it on every chunk is quadratic, and no benign warning
+        // is anywhere near this length, so holding it buys nothing.
+        if (carry.length > MAX_HELD_LINE_CHARS) {
+          const released = carry
+          carry = ''
+          return released
+        }
+        return ''
+      }
+      const complete = carry.slice(0, lastNewline + 1)
+      carry = carry.slice(lastNewline + 1)
+      return stripBenignChatRuntimeWarnings(complete)
+    },
+    /**
+     * Emit whatever is still held, filtered. Must be called when the stream ends: a runtime that
+     * does not terminate its final line would otherwise have that line dropped entirely.
+     */
+    flush(): string {
+      if (!carry) return ''
+      const remaining = stripBenignChatRuntimeWarnings(carry)
+      carry = ''
+      return remaining
+    },
+  }
+}
+
 export function normalizeChatMessage(content: string): string {
   if (!content) return content
 

--- a/SYSTEM/dashboard/server/lib/streaming-warning-filter.test.ts
+++ b/SYSTEM/dashboard/server/lib/streaming-warning-filter.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The streaming warning filter.
+ *
+ * Origin: a boxed CLI warning arrived split across two stream chunks, neither half matched the
+ * line-based filter, and the fragments rendered in chat as the agent's entire reply — the real
+ * answer had been stripped from the final text, so the client fell back to what it had streamed.
+ *
+ * Several lanes below exist because a first version of this fix introduced NEW defects: it deleted
+ * newlines at chunk boundaries, leaked every non-boxed warning, and never released its final held
+ * line. Those lanes assert the absence of each.
+ */
+import assert from 'assert'
+import { createStreamingWarningFilter, stripBenignChatRuntimeWarnings } from './chat-normalization'
+
+const GREEN = '\x1b[32m', RED = '\x1b[31m', RESET = '\x1b[0m'
+let passed = 0, failed = 0
+function test(name: string, fn: () => void) {
+  try { fn(); console.log(`${GREEN}✓${RESET} ${name}`); passed++ }
+  catch (err: any) { console.log(`${RED}✗${RESET} ${name}`); console.log(`  ${err.message}`); failed++ }
+}
+
+/** The exact line observed in the live deployment. */
+const BOXED = '│    ignored; remove it from plugins config)                              │'
+
+test('a warning split across chunks is filtered', () => {
+  const f = createStreamingWarningFilter()
+  const half = Math.floor(BOXED.length / 2)
+  const out = f.push(BOXED.slice(0, half)) + f.push(BOXED.slice(half) + '\n') + f.flush()
+  assert.strictEqual(out.trim(), '', `expected nothing visible, got ${JSON.stringify(out)}`)
+})
+
+test('per-chunk filtering demonstrably leaks it — why this exists', () => {
+  const half = Math.floor(BOXED.length / 2)
+  const leaked = stripBenignChatRuntimeWarnings(BOXED.slice(0, half))
+    + stripBenignChatRuntimeWarnings(BOXED.slice(half))
+  assert.notStrictEqual(leaked.trim(), '',
+    'per-chunk filtering should leak a split warning; if it no longer does, this lane is obsolete')
+})
+
+test('newlines survive chunk boundaries exactly', () => {
+  // Regression: an earlier version returned "First lineSecond", silently joining a paragraph to
+  // whatever followed it — which corrupts a markdown table that comes after prose.
+  const f = createStreamingWarningFilter()
+  const out = f.push('First line') + f.push('\nSecond') + f.flush()
+  assert.strictEqual(out, 'First line\nSecond', `newline lost: ${JSON.stringify(out)}`)
+})
+
+test('a run of blank lines is preserved, not collapsed', () => {
+  const f = createStreamingWarningFilter()
+  const out = f.push('a\n\n\nb\n') + f.flush()
+  assert.strictEqual(out, 'a\n\n\nb\n', `blank lines altered: ${JSON.stringify(out)}`)
+})
+
+test('non-boxed warnings are filtered too, even when split', () => {
+  // Regression: buffering only box-drawing prefixes let every other warning form through the
+  // moment it was split, which is the original bug in a narrower disguise.
+  const f = createStreamingWarningFilter()
+  const w = 'plugin not found: ghost (stale config entry ignored; remove it from plugins config)'
+  const out = f.push(w.slice(0, 20)) + f.push(w.slice(20) + '\n') + f.flush()
+  assert.strictEqual(out.trim(), '', `non-boxed warning leaked: ${JSON.stringify(out)}`)
+})
+
+test('flush releases a final line the runtime never terminated', () => {
+  // Regression: without a flush call the last unterminated line was dropped from the stream AND
+  // from fullOutput, which drives persisted-answer recovery — so the loss was permanent.
+  const f = createStreamingWarningFilter()
+  assert.strictEqual(f.push('Intro\n| final table row |'), 'Intro\n')
+  assert.strictEqual(f.flush(), '| final table row |', 'the held final line must be released')
+})
+
+test('a markdown table streams intact once its lines complete', () => {
+  const f = createStreamingWarningFilter()
+  const table = '| a | b |\n|---|---|\n| 1 | 2 |\n'
+  const out = f.push(table.slice(0, 12)) + f.push(table.slice(12)) + f.flush()
+  assert.strictEqual(out, table, `table corrupted: ${JSON.stringify(out)}`)
+})
+
+test('real output around a warning keeps only the real output, in order', () => {
+  const f = createStreamingWarningFilter()
+  const out = f.push(`Working on it.\n${BOXED}\nStill working.\n`) + f.flush()
+  assert.strictEqual(out, 'Working on it.\nStill working.\n', `got ${JSON.stringify(out)}`)
+})
+
+test('an absurdly long unterminated line is released rather than buffered forever', () => {
+  // Holding it would re-scan a growing string on every chunk (quadratic) for no benefit: no benign
+  // warning is anywhere near this length.
+  const f = createStreamingWarningFilter()
+  let out = ''
+  for (let i = 0; i < 10; i++) out += f.push('x'.repeat(1024))
+  assert.ok(out.length > 0, 'a >8KB unterminated line must be released, not held indefinitely')
+})
+
+test('nothing is emitted twice across push and flush', () => {
+  const f = createStreamingWarningFilter()
+  const out = f.push('alpha\nbeta') + f.flush() + f.flush()
+  assert.strictEqual(out, 'alpha\nbeta', `duplicated or lost content: ${JSON.stringify(out)}`)
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/SYSTEM/dashboard/server/routes/chat.ts
+++ b/SYSTEM/dashboard/server/routes/chat.ts
@@ -9,7 +9,7 @@ import { getRequestDashboardInstanceId, traceAgentChat } from '../lib/opik'
 import { hasWorkspaceManagedPartnerSecrets, readWorkspaceIntegrationConfig } from '../lib/workspace-integrations'
 import { userExecutionEnv } from '../lib/safe-env'
 import { checkBudgetBlock } from '../lib/budget'
-import { normalizeChatMessage, stripBenignChatRuntimeWarnings } from '../lib/chat-normalization'
+import { createStreamingWarningFilter, normalizeChatMessage, stripBenignChatRuntimeWarnings } from '../lib/chat-normalization'
 import { resolveOpenClawCliPath } from '../lib/openclaw-cli'
 import { getAgentSkills, getAssignedSkillPromptNotes, getSkillById } from '../lib/skills'
 import { executeClawmaxResendSend } from '../lib/clawmax-resend-command'
@@ -861,6 +861,28 @@ router.post('/:id/chat', async (req, res) => {
         send('start', { sessionId: executionSessionId, resumeSessionId: attemptSessionSeed })
         invalidateAgentStatusCache(id)
 
+        // Line-buffered rather than per-chunk. stripBenignChatRuntimeWarnings matches whole lines,
+        // and a boxed CLI warning routinely arrives split across two chunks -- neither half matches,
+        // so both were forwarded. The final text IS filtered and came back empty, and the client
+        // falls back to the streamed fragments when `complete` carries no text, so the warning
+        // became the agent's entire reply.
+        const attemptDeltaFilter = createStreamingWarningFilter()
+
+        /**
+         * Release the held final line into fullOutput and the stream.
+         *
+         * MUST run before a settlement path builds its result: `completionText` is derived from
+         * fullOutput, so flushing afterwards streams the tail as a delta and then sends a
+         * `complete` without it -- the user watches the last line appear and then vanish.
+         */
+        const flushStreamTail = () => {
+          const tail = attemptDeltaFilter.flush()
+          if (!tail) return
+          fullOutput = appendBoundedOutput(fullOutput, tail, MAX_RETAINED_CHAT_OUTPUT)
+          hadVisibleOutput = true
+          send('delta', { text: tail })
+        }
+
         const stopIncompleteAttempt = (reason: string) => {
           if (incompleteReason) return
           incompleteReason = reason
@@ -889,7 +911,7 @@ router.post('/:id/chat', async (req, res) => {
         spawned.stdout.on('data', (chunk: Buffer) => {
           bumpAttemptIdle()
           if (!recordOutputBytes(chunk)) return
-          const text = stripBenignChatRuntimeWarnings(chunk.toString())
+          const text = attemptDeltaFilter.push(chunk.toString())
           if (!text) return
           fullOutput = appendBoundedOutput(fullOutput, text, MAX_RETAINED_CHAT_OUTPUT)
           hadVisibleOutput = true
@@ -905,6 +927,8 @@ router.post('/:id/chat', async (req, res) => {
         spawned.on('exit', () => { procExited = true })
 
         spawned.on('close', async (code) => {
+          // Before anything reads fullOutput -- normalizedText below is derived from it.
+          flushStreamTail()
           if (activeAttemptTimer) {
             clearTimeout(activeAttemptTimer)
             activeAttemptTimer = null


### PR DESCRIPTION
Fixes clawmax-cli#55.

## The bug

A benign CLI warning can become an agent's **entire chat reply**. Observed live on `2.0.0-test-rc38`:

> **user:** what are you working on
> **agent:** `│    ignored; remove it from plugins config)                              │`

The real answer never appeared, and nothing indicated a warning was involved — it reads as the agent malfunctioning.

## Why

`stripBenignChatRuntimeWarnings` matches **whole lines** and does strip that text. But the stream is filtered **per chunk** (`routes/chat.ts:892`), and a boxed warning routinely arrives split across two chunks — neither half matches a line pattern, so both are forwarded.

The final text *is* filtered, which is what makes it total: it comes back empty, and `AgentChatPanel` keeps whatever was streamed when `complete` carries no text. So the fragments become the reply.

## The fix

Line-buffer the stream: hold the incomplete trailing line until its newline arrives, then filter it as a line.

Two details that earlier attempts got wrong, both caught by independent review:

- **Preserve newlines by slicing, not `split`/`join`.** Dropping a separator silently joins a paragraph to the table after it.
- **Hold every incomplete line, not just warning-shaped ones.** Buffering only box-drawing prefixes — to avoid delaying prose — lets every other warning form through the moment it splits. Output here is line-oriented, so the wait is bounded by the next newline; anything unterminated past 8KB is released, since re-scanning a growing buffer per chunk is quadratic.

The held tail is flushed **before** the close handler reads `fullOutput`. Flushing later streams the tail as a delta and then sends a `complete` without it — the user watches the final line appear and then vanish.

## Tests

10 lanes: split warnings, newline preservation across chunk boundaries, blank-line runs, non-boxed warnings, flush releasing an unterminated final line, markdown table integrity, ordering, no double-emit, and the 8KB release.

One lane asserts that **per-chunk filtering still leaks**, so this fix cannot be silently reverted.

`chat` 33, `chat-normalization` 18, `chat-process-safety` 17, typecheck clean — all against `main` plus this change.

## Review history

Two independent GPT-5.6-sol reviews rejected earlier versions: the first for deleting newlines at chunk boundaries, leaking non-boxed warnings, never flushing, and quadratic cost; the second for flushing after the result was already built. Both were right; both are addressed here.

## Scope note

The Claude/Droid path does not need this and is untouched — `createClaudeStreamDeltaTransformer` emits only text blocks from parsed `assistant` events, so a raw CLI warning cannot reach it. (That path exists in #170, not on `main`.)

This is self-contained and independent of #170, which carries the same fix among 58 other commits.