### PR TITLE
feat: add NYU AgentForge partner catalog entry

### DIFF
--- a/PARTNERS/agentforge/PARTNER.md
+++ b/PARTNERS/agentforge/PARTNER.md
@@ -1,0 +1,28 @@
+# NYU - AgentForge
+
+AgentForge is the onboarding, learning-support, Prompt evidence, and progress layer for NYU personal-agent hackathons. Participants complete registration, privacy consent, the dynamic survey, foundational tutorials, and progress review in AgentForge, then continue to ClawMax to build and run their personal agents.
+
+## Activity Export role
+
+AgentForge is an optional, explicitly selected Activity Export destination. Selecting the Partner card makes AgentForge available for the workspace; it does not by itself authorize activity sharing.
+
+Activity may be delivered only when:
+
+- the participant has an active AgentForge consent receipt;
+- the exported source is included in that receipt's scopes;
+- ClawMax can map the participant and workspace to the AgentForge enrollment; and
+- the server-side AgentForge endpoint and Partner credential are configured.
+
+Eligible launch evidence can include consented agent-chat Prompts and responses, selected context, Builder actions, workflow activity, execution errors, and agent test results. ClawMax redacts eligible activity before its durable outbox. AgentForge validates, normalizes, stores, and links accepted evidence before it is used for progress support, Prompt coaching, Organizer analysis, or Cognee memory.
+
+## Privacy and revocation
+
+AgentForge owns the participant-facing privacy notice, purpose disclosure, scope selection, retention disclosure, and withdrawal experience. ClawMax enforces the resulting receipt during capture and delivery.
+
+Revocation stops new capture synchronously and removes undelivered events associated with the revoked receipt. Deletion of evidence already delivered to AgentForge follows AgentForge's receipt-linked purge process, including derived Cognee memory where applicable.
+
+Partner API keys are deployment secrets. They must remain server-managed and must never be shown to participants, embedded in browser configuration, committed to Git, or included in exported activity.
+
+## Current integration boundary
+
+The public Partner definition provides AgentForge catalog metadata and configuration requirements. Cloud account provisioning, opaque participant/workspace mapping, consent-receipt synchronization, and the production Activity Export adapter remain subject to the shared ClawMax-AgentForge implementation profile and conformance tests.

--- a/PARTNERS/agentforge/PARTNER.md
+++ b/PARTNERS/agentforge/PARTNER.md
@@ -2,9 +2,15 @@
 
 AgentForge is the onboarding, learning-support, Prompt evidence, and progress layer for NYU personal-agent hackathons. Participants complete registration, privacy consent, the dynamic survey, foundational tutorials, and progress review in AgentForge, then continue to ClawMax to build and run their personal agents.
 
+This catalog entry introduces AgentForge as a planned Activity Export partner.
+It does not yet provide AgentForge endpoint configuration, consent controls, or
+activity delivery in ClawMax.
+
 ## Activity Export role
 
-AgentForge is an optional, explicitly selected Activity Export destination. Selecting the Partner card makes AgentForge available for the workspace; it does not by itself authorize activity sharing.
+AgentForge is planned as an optional, explicitly selected Activity Export
+destination. Selecting the Partner card makes AgentForge visible to the
+workspace; it does not configure the destination or authorize activity sharing.
 
 Activity may be delivered only when:
 
@@ -25,4 +31,8 @@ Partner API keys are deployment secrets. They must remain server-managed and mus
 
 ## Current integration boundary
 
-The public Partner definition provides AgentForge catalog metadata and configuration requirements. Cloud account provisioning, opaque participant/workspace mapping, consent-receipt synchronization, and the production Activity Export adapter remain subject to the shared ClawMax-AgentForge implementation profile and conformance tests.
+The public Partner definition currently provides catalog metadata only. Cloud
+account provisioning, endpoint and credential configuration, opaque
+participant/workspace mapping, consent-receipt synchronization, client consent
+and status controls, and the production Activity Export adapter remain subject
+to the shared ClawMax-AgentForge implementation profile and conformance tests.

--- a/PARTNERS/agentforge/partner.json
+++ b/PARTNERS/agentforge/partner.json
@@ -1,0 +1,34 @@
+{
+  "slug": "agentforge",
+  "name": "NYU - AgentForge",
+  "logoUrl": "https://agentforge-hackathon-os.yr2110.chatgpt.site/favicon.svg",
+  "website": "https://agentforge-hackathon-os.yr2110.chatgpt.site/",
+  "docsUrl": "https://github.com/Wukuai2333/agentforge-hackathon-os",
+  "description": "Opt-in learning support, Prompt evidence, and progress tracking for personal-agent hackathons.",
+  "category": "monitoring",
+  "categories": ["monitoring", "context"],
+  "enabledByDefault": true,
+  "fields": [
+    {
+      "key": "apiKey",
+      "label": "Partner API key",
+      "type": "password",
+      "required": false,
+      "secret": true,
+      "storage": "server"
+    },
+    {
+      "key": "apiUrl",
+      "label": "AgentForge ingestion API URL",
+      "type": "text",
+      "required": false,
+      "secret": false,
+      "storage": "server"
+    }
+  ],
+  "validation": {
+    "mode": "status",
+    "label": "Connection status",
+    "helperText": "ClawMax Cloud operators configure the AgentForge HTTPS ingestion URL and server-managed partner key. Selecting AgentForge only makes the destination available; activity is sent only after the participant has an active AgentForge consent receipt."
+  }
+}

--- a/PARTNERS/agentforge/partner.json
+++ b/PARTNERS/agentforge/partner.json
@@ -3,32 +3,9 @@
   "name": "NYU - AgentForge",
   "logoUrl": "https://agentforge-hackathon-os.yr2110.chatgpt.site/favicon.svg",
   "website": "https://agentforge-hackathon-os.yr2110.chatgpt.site/",
-  "docsUrl": "https://github.com/Wukuai2333/agentforge-hackathon-os",
-  "description": "Opt-in learning support, Prompt evidence, and progress tracking for personal-agent hackathons.",
+  "docsUrl": "https://github.com/Maximilien-ai/clawmax/blob/main/PARTNERS/agentforge/PARTNER.md",
+  "description": "Planned opt-in learning support, Prompt evidence, and progress tracking for personal-agent hackathons.",
   "category": "monitoring",
   "categories": ["monitoring", "context"],
-  "enabledByDefault": true,
-  "fields": [
-    {
-      "key": "apiKey",
-      "label": "Partner API key",
-      "type": "password",
-      "required": false,
-      "secret": true,
-      "storage": "server"
-    },
-    {
-      "key": "apiUrl",
-      "label": "AgentForge ingestion API URL",
-      "type": "text",
-      "required": false,
-      "secret": false,
-      "storage": "server"
-    }
-  ],
-  "validation": {
-    "mode": "status",
-    "label": "Connection status",
-    "helperText": "ClawMax Cloud operators configure the AgentForge HTTPS ingestion URL and server-managed partner key. Selecting AgentForge only makes the destination available; activity is sent only after the participant has an active AgentForge consent receipt."
-  }
+  "enabledByDefault": true
 }

--- a/SYSTEM/dashboard/client/src/components/PartnerLogo.test.ts
+++ b/SYSTEM/dashboard/client/src/components/PartnerLogo.test.ts
@@ -35,4 +35,10 @@ test('partner logo has a compact icon fallback when a remote logo is unavailable
   assert(!markup.includes('>Digo</span>'), 'Fallback should not consume the full partner name')
 })
 
+test('NYU - AgentForge uses the AgentForge glyph when its remote logo is unavailable', () => {
+  const markup = renderToStaticMarkup(React.createElement(PartnerLogo, { slug: 'agentforge', name: 'NYU - AgentForge' }))
+  assert(markup.includes('aria-label="NYU - AgentForge logo"'), 'Expected accessible AgentForge fallback label')
+  assert(markup.includes('>A</span>'), 'Expected AgentForge fallback glyph instead of the NYU initial')
+})
+
 console.log('PartnerLogo.test.ts: ok')

--- a/SYSTEM/dashboard/client/src/components/PartnerLogo.ts
+++ b/SYSTEM/dashboard/client/src/components/PartnerLogo.ts
@@ -8,11 +8,11 @@ type PartnerLogoProps = {
   variant?: 'compact' | 'hero'
 }
 
-function fallbackLogo(className: string, name: string) {
+function fallbackLogo(className: string, slug: string, name: string) {
   const glyphs: Record<string, string> = {
-    cognee: 'C', digo: 'D', gmail: 'G', microsoft365: 'M', 'nyu - agentforge': 'A', opik: 'O', resend: 'R', senso: 'S',
+    agentforge: 'A', cognee: 'C', digo: 'D', gmail: 'G', microsoft365: 'M', opik: 'O', resend: 'R', senso: 'S',
   }
-  const glyph = glyphs[name.toLowerCase()] || name.trim().slice(0, 1).toUpperCase() || '?'
+  const glyph = glyphs[slug.toLowerCase()] || name.trim().slice(0, 1).toUpperCase() || '?'
   return React.createElement(
     'span',
     {
@@ -31,7 +31,7 @@ export function PartnerLogo({ slug, name, logoUrl, variant = 'compact' }: Partne
   const chipClassName = `${className} inline-flex items-center justify-center overflow-hidden`
 
   if (!logoUrl || imageFailed) {
-    return fallbackLogo(className, name)
+    return fallbackLogo(className, slug, name)
   }
 
   return React.createElement(

--- a/SYSTEM/dashboard/client/src/components/PartnerLogo.ts
+++ b/SYSTEM/dashboard/client/src/components/PartnerLogo.ts
@@ -10,7 +10,7 @@ type PartnerLogoProps = {
 
 function fallbackLogo(className: string, name: string) {
   const glyphs: Record<string, string> = {
-    cognee: 'C', digo: 'D', gmail: 'G', microsoft365: 'M', opik: 'O', resend: 'R', senso: 'S',
+    cognee: 'C', digo: 'D', gmail: 'G', microsoft365: 'M', 'nyu - agentforge': 'A', opik: 'O', resend: 'R', senso: 'S',
   }
   const glyph = glyphs[name.toLowerCase()] || name.trim().slice(0, 1).toUpperCase() || '?'
   return React.createElement(

--- a/SYSTEM/dashboard/client/src/lib/defaultPartners.test.ts
+++ b/SYSTEM/dashboard/client/src/lib/defaultPartners.test.ts
@@ -1,0 +1,17 @@
+import assert from 'assert'
+import { DEFAULT_PARTNER_DEFINITIONS, DEFAULT_VISIBLE_PARTNERS } from './defaultPartners'
+
+const agentforge = DEFAULT_PARTNER_DEFINITIONS.find((partner) => partner.slug === 'agentforge')
+
+assert(DEFAULT_VISIBLE_PARTNERS.includes('agentforge'), 'Expected AgentForge in the resilient visible-partner fallback')
+assert(agentforge, 'Expected AgentForge in the resilient partner-definition fallback')
+assert((agentforge.fields || []).length === 0, 'Catalog-only AgentForge fallback must not expose inactive export configuration fields')
+assert(!agentforge.validation, 'Catalog-only AgentForge fallback must not imply connection validation is available')
+assert(/planned opt-in/i.test(agentforge.description), 'Expected AgentForge fallback to disclose planned status')
+assert.strictEqual(
+  agentforge.docsUrl,
+  'https://github.com/Maximilien-ai/clawmax/blob/main/PARTNERS/agentforge/PARTNER.md',
+  'Expected AgentForge fallback to link its specific public setup document',
+)
+
+console.log('defaultPartners.test.ts: ok')

--- a/SYSTEM/dashboard/client/src/lib/defaultPartners.ts
+++ b/SYSTEM/dashboard/client/src/lib/defaultPartners.ts
@@ -29,7 +29,7 @@ export type DefaultPartnerDefinition = {
   }
 }
 
-export const DEFAULT_VISIBLE_PARTNERS = ['senso', 'opik', 'github', 'resend', 'cognee', 'gmail', 'microsoft365', 'digo'] as const
+export const DEFAULT_VISIBLE_PARTNERS = ['senso', 'opik', 'github', 'resend', 'cognee', 'gmail', 'microsoft365', 'digo', 'agentforge'] as const
 
 export const DEFAULT_PARTNER_DEFINITIONS: DefaultPartnerDefinition[] = [
   {
@@ -240,6 +240,26 @@ export const DEFAULT_PARTNER_DEFINITIONS: DefaultPartnerDefinition[] = [
       mode: 'status',
       label: 'Connection status',
       helperText: 'Digo activity export is available when the operator configures an HTTPS ingestion URL and server-managed API key. User consent is still required before any activity is sent.',
+    },
+  },
+  {
+    slug: 'agentforge',
+    name: 'NYU - AgentForge',
+    logoUrl: 'https://agentforge-hackathon-os.yr2110.chatgpt.site/favicon.svg',
+    website: 'https://agentforge-hackathon-os.yr2110.chatgpt.site/',
+    docsUrl: 'https://github.com/Wukuai2333/agentforge-hackathon-os',
+    description: 'Opt-in learning support, Prompt evidence, and progress tracking for personal-agent hackathons.',
+    category: 'monitoring',
+    categories: ['monitoring', 'context'],
+    enabledByDefault: true,
+    fields: [
+      { key: 'apiKey', label: 'Partner API key', type: 'password', required: false, secret: true, storage: 'server' },
+      { key: 'apiUrl', label: 'AgentForge ingestion API URL', type: 'text', required: false, secret: false, storage: 'server' },
+    ],
+    validation: {
+      mode: 'status',
+      label: 'Connection status',
+      helperText: 'ClawMax Cloud operators configure the AgentForge HTTPS ingestion URL and server-managed partner key. Selecting AgentForge only makes the destination available; activity is sent only after the participant has an active AgentForge consent receipt.',
     },
   },
 ]

--- a/SYSTEM/dashboard/client/src/lib/defaultPartners.ts
+++ b/SYSTEM/dashboard/client/src/lib/defaultPartners.ts
@@ -247,20 +247,11 @@ export const DEFAULT_PARTNER_DEFINITIONS: DefaultPartnerDefinition[] = [
     name: 'NYU - AgentForge',
     logoUrl: 'https://agentforge-hackathon-os.yr2110.chatgpt.site/favicon.svg',
     website: 'https://agentforge-hackathon-os.yr2110.chatgpt.site/',
-    docsUrl: 'https://github.com/Wukuai2333/agentforge-hackathon-os',
-    description: 'Opt-in learning support, Prompt evidence, and progress tracking for personal-agent hackathons.',
+    docsUrl: 'https://github.com/Maximilien-ai/clawmax/blob/main/PARTNERS/agentforge/PARTNER.md',
+    description: 'Planned opt-in learning support, Prompt evidence, and progress tracking for personal-agent hackathons.',
     category: 'monitoring',
     categories: ['monitoring', 'context'],
     enabledByDefault: true,
-    fields: [
-      { key: 'apiKey', label: 'Partner API key', type: 'password', required: false, secret: true, storage: 'server' },
-      { key: 'apiUrl', label: 'AgentForge ingestion API URL', type: 'text', required: false, secret: false, storage: 'server' },
-    ],
-    validation: {
-      mode: 'status',
-      label: 'Connection status',
-      helperText: 'ClawMax Cloud operators configure the AgentForge HTTPS ingestion URL and server-managed partner key. Selecting AgentForge only makes the destination available; activity is sent only after the participant has an active AgentForge consent receipt.',
-    },
   },
 ]
 

--- a/SYSTEM/dashboard/server/lib/partners.test.ts
+++ b/SYSTEM/dashboard/server/lib/partners.test.ts
@@ -99,14 +99,15 @@ test('digo partner exposes server API key and HTTPS ingestion URL fields', () =>
   assert(/consent/i.test(partner.validation?.helperText || ''), 'Expected Digo readiness copy to mention consent')
 })
 
-test('agentforge partner exposes NYU branding and server-managed Activity Export fields', () => {
+test('agentforge partner is honest about its catalog-only Activity Export boundary', () => {
   process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES = 'agentforge'
   const partner = listPartnerDefinitions()[0]
   assert(partner.slug === 'agentforge', 'Expected agentforge partner')
   assert(partner.name === 'NYU - AgentForge', 'Expected NYU - AgentForge display name')
-  assert(partner.fields?.some((field) => field.key === 'apiKey' && field.secret === true && field.storage === 'server') === true, 'Expected AgentForge server-stored Partner API key field')
-  assert(partner.fields?.some((field) => field.key === 'apiUrl' && field.secret !== true && field.storage === 'server') === true, 'Expected AgentForge ingestion URL field')
-  assert(/active AgentForge consent receipt/i.test(partner.validation?.helperText || ''), 'Expected AgentForge readiness copy to preserve the consent gate')
+  assert((partner.fields || []).length === 0, 'Catalog-only AgentForge entry must not expose inactive export configuration fields')
+  assert(!partner.validation, 'Catalog-only AgentForge entry must not imply that connection validation is available')
+  assert(/planned opt-in/i.test(partner.description), 'Expected AgentForge description to disclose planned status')
+  assert(partner.docsUrl === 'https://github.com/Maximilien-ai/clawmax/blob/main/PARTNERS/agentforge/PARTNER.md', 'Expected a specific public setup document')
 })
 
 if (typeof previous === 'undefined') delete process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES

--- a/SYSTEM/dashboard/server/lib/partners.test.ts
+++ b/SYSTEM/dashboard/server/lib/partners.test.ts
@@ -37,14 +37,14 @@ const previous = process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES
 test('getEnabledPartnerSlugs defaults to current partner parity set', () => {
   delete process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES
   const slugs = getEnabledPartnerSlugs()
-  assert(slugs.join(',') === 'senso,opik,github,resend,cognee,gmail,microsoft365,digo', `Unexpected default partner slugs: ${slugs.join(',')}`)
+  assert(slugs.join(',') === 'senso,opik,github,resend,cognee,gmail,microsoft365,digo,agentforge', `Unexpected default partner slugs: ${slugs.join(',')}`)
 })
 
 test('legacy default allowlist gains newly shipped default partners', () => {
   process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES = 'github,senso,opik,resend,cognee'
   const partners = listPartnerDefinitions()
   const slugs = partners.map((partner) => partner.slug)
-  assert(slugs.join(',') === 'senso,opik,github,resend,cognee,gmail,microsoft365,digo', `Unexpected migrated partners: ${slugs.join(',')}`)
+  assert(slugs.join(',') === 'senso,opik,github,resend,cognee,gmail,microsoft365,digo,agentforge', `Unexpected migrated partners: ${slugs.join(',')}`)
 })
 
 test('custom partner allowlist remains explicit', () => {
@@ -97,6 +97,16 @@ test('digo partner exposes server API key and HTTPS ingestion URL fields', () =>
   assert(partner.fields?.some((field) => field.key === 'apiKey' && field.secret === true && field.storage === 'server') === true, 'Expected Digo server-stored API key field')
   assert(partner.fields?.some((field) => field.key === 'apiUrl' && field.secret !== true) === true, 'Expected Digo ingestion URL field')
   assert(/consent/i.test(partner.validation?.helperText || ''), 'Expected Digo readiness copy to mention consent')
+})
+
+test('agentforge partner exposes NYU branding and server-managed Activity Export fields', () => {
+  process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES = 'agentforge'
+  const partner = listPartnerDefinitions()[0]
+  assert(partner.slug === 'agentforge', 'Expected agentforge partner')
+  assert(partner.name === 'NYU - AgentForge', 'Expected NYU - AgentForge display name')
+  assert(partner.fields?.some((field) => field.key === 'apiKey' && field.secret === true && field.storage === 'server') === true, 'Expected AgentForge server-stored Partner API key field')
+  assert(partner.fields?.some((field) => field.key === 'apiUrl' && field.secret !== true && field.storage === 'server') === true, 'Expected AgentForge ingestion URL field')
+  assert(/active AgentForge consent receipt/i.test(partner.validation?.helperText || ''), 'Expected AgentForge readiness copy to preserve the consent gate')
 })
 
 if (typeof previous === 'undefined') delete process.env.WORKSPACES_INTEGRATIONS_THIRD_PARTIES

--- a/SYSTEM/dashboard/server/lib/partners.ts
+++ b/SYSTEM/dashboard/server/lib/partners.ts
@@ -44,7 +44,7 @@ export interface PartnerDefinition {
   sourceRoot?: string
 }
 
-export const DEFAULT_PARTNERS = ['senso', 'opik', 'github', 'resend', 'cognee', 'gmail', 'microsoft365', 'digo'] as const
+export const DEFAULT_PARTNERS = ['senso', 'opik', 'github', 'resend', 'cognee', 'gmail', 'microsoft365', 'digo', 'agentforge'] as const
 const LEGACY_DEFAULT_PARTNERS = ['senso', 'opik', 'github', 'resend', 'cognee'] as const
 
 function splitList(raw: string | undefined): string[] {


### PR DESCRIPTION
## Summary
- add the public `PARTNERS/agentforge` definition and setup documentation
- display the Partner as **NYU - AgentForge** while keeping the stable internal slug `agentforge`
- add AgentForge to the server/client Partner allowlists and resilient client fallback catalog
- label Activity Export as planned until AgentForge consent, delivery, and receiver conformance work is complete
- link the catalog to the specific public AgentForge integration page
- add focused server, fallback-catalog, and logo coverage

## Validation
- Partner definition suite: 8 passed, 0 failed
- Partner fallback catalog suite: passed
- Partner logo suite: 3 passed
- `npm run typecheck`: passed

## Integration boundary
This PR adds the Partner catalog surface only. It does not expose endpoint or credential controls and does not offer AgentForge in the Activity Export consent UI. Cloud provisioning, opaque participant/workspace mapping, AgentForge consent-receipt synchronization, the production Activity Export adapter, and receiver conformance remain separate work.

No local Activity Export state or credentials are included.
